### PR TITLE
Hotfix v0.01.1

### DIFF
--- a/LibLunacy/AssetLoader.cs
+++ b/LibLunacy/AssetLoader.cs
@@ -208,16 +208,21 @@ namespace LibLunacy
 		{
 			IGFile main = fm.igfiles["main.dat"];
 			IGFile.SectionHeader zoneSection = main.QuerySection(0x5000);
+			Console.WriteLine($"{zoneSection.count} zones detected (0x{zoneSection.length:X} bytes long)");
 			for (int i = 0; i < zoneSection.count; i++)
 			{
-				CZone zone = new(main, this);
-				zone.index = i;
+                CZone zone = new(main, this)
+                {
+                    index = i
+                };
 
-				Console.WriteLine("[0x{0:X}] Zone {1} ({2}) has {3} ufrags", "unk", zone.name, i, zone.ufrags?.Length ?? 0);
+                Console.WriteLine("[0x{0:X}] Zone {1} ({2}/{3}) has {4} ufrags", "unk", zone.name, i, zoneSection.count, zone.ufrags.Length);
 				zones.Add((ulong)i, zone);
 
 				ufrags.Add((ulong)zone.index, new());
 				var locUfrags = ufrags[(ulong)zone.index];
+
+				if (zone.ufrags is null) continue;
                 for (int j = 0; j < zone.ufrags.Length; j++)
                 {
                     locUfrags.Add(zone.ufrags[j].GetTuid(), zone.ufrags[j]);

--- a/LibLunacy/Zone.cs
+++ b/LibLunacy/Zone.cs
@@ -214,11 +214,13 @@ namespace LibLunacy
 			}
 
 			//ufrags = new NewUFrag[0];
-			
-			LoadTFrags(file, al);
+
+			ufrags = Array.Empty<UFrag>();
+			if (al.fm.isOld) return;
+			LoadUFrags(file, al);
 		}
 
-		private void LoadTFrags(IGFile file, AssetLoader al)
+		private void LoadUFrags(IGFile file, AssetLoader al)
 		{
 			IGFile.SectionHeader ufragSection;
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,79 @@
-# Lunacy Level Editor
+<h1>
+<p align="center">
+  <!--<img src="media/ReplanetizerIcon500px.ico" alt="Logo" width="110" height="110" title="Logo made by Nooga.">  Replanetizer leftovers :p-->
+  <p align="center" style="font-weight: bold">ReLunacy</p>
+</h1>
+  <p align="center">
+    Level Editor for the Ratchet and Clank: Future Series and Resistance PS3 opuses
+    <br/>
+    </p>
+</p>
+<p align="center">
+  <a href="#features">Features</a> •
+  <a href="#usage">Usage</a> •
+  <!--<a href="#building">Building</a> •
+  <a href="#technology">Technology</a> •
+  <a href="#licensing">Licensing</a> •
+  <a href="CONTRIBUTING.md">Contributing</a>-->
+</p>
 
-Level editor for the Ratchet and Clank PS3 games along with the Resistance series
+<p align="center">
+  <img src="media/preview.gif" alt="Preview">
+</p>
+
+## Features
+
+ReLunacy is still in early development, but it comes with very interesting features, modders and speedrunners will really like it.
+
+- Visualize levels
+  - Mobys, Ties and UFrags (terrain)
+  - Triggers & Volumes
+  - Light sources (WIP)
+- Editing (WIP)
+- Export (WIP)
+  - Thanks to [@NefariousTechSupport](https://github.com/NefariousTechSupport?tab=repositories), the AssetExtractor tool works for the essential things, but I will soon be implementing a better exportation tool directly in the level editor.
+- Flexible editor
+  - Almost everything in the editor can be edited in Editor settings; camera speed, field of view, overlay, stats profiler, renderer...
+  - Dockable UI made for people who like to organise their work.
+  - Comfortable and user-friendly; the editor is made to be easy to use.
+  - (WIP) Customize the rendering by adding your own shaders to the editor.
 
 ## Building
-
 * cd into the directory with the `Lunacy.sln` file
 * Run `dotnet build`
 
 ## Running
 
-### Lunacy
+### ReLunacy
 
-* Run `Lunacy.exe <path to folder>`, where the folder contains either the `main.dat` file or the `assetlookup.dat` file
-* if `assetlookup.dat` is there, `highmips.dat` from `level_uncached.psarc` must be included as well
-* Controls are as such:
-  * hold right click + move mouse to look around
-  * wasd to move, shift to move faster
-  * p shows the names of all objects that the mouse is hovering over
-  * select an object in either the regions or zones windows to teleport to that object
+- Run `ReLunacy.exe` by double-clicking it, or execute `./ReLunacy.exe <path to level folder>`.
+- From the menu bar, access `File > Load Level` and enter the path to the level folder.
+  - The folder is the folder that contains either `main.dat` or `assetlookup.dat` file.
+  - If `assetlookup.dat` is there, `highmips.dat` from `level_uncached.psarc` must be included as well.
+- Controls:
+  - `[RMB]+[Move]` to look around
+  - `[W][A][S][D]` or `[Z][Q][S][D]` to move arond (depending on locale)
+  - `[SHIFT]` to move faster
+  - `[E][Q]` or `[E][A]` to move up and down (depending on locale)
+
+### Lunacy [Deprecated]
+
+- Run `Lunacy.exe <path to folder>`, where the folder contains either the `main.dat` file or the `assetlookup.dat` file
+- if `assetlookup.dat` is there, `highmips.dat` from `level_uncached.psarc` must be included as well
+- Controls are as such:
+  - `[RMB]`+`[Move]` to look around
+  - `[W][A][S][D]` or `[Z][Q][S][D]`to move, `[SHIFT]` to move faster
+  - `[P]` shows the names of all objects that the mouse is hovering over
+  - Select an object in either the regions or zones windows to teleport to that object
+- Add the command argument `--load-ufrags` to load UFrags in Lunacy Legacy.
 
 ### AssetExtractor
 
 * Run `AssetExtractor.exe <path to folder>`, where the folder contains either the `main.dat` file or the `assetlookup.dat` file
-* if `assetlookup.dat` is there, `highmips.dat` from `level_uncached.psarc` must be included as well
+* If `assetlookup.dat` is there, `highmips.dat` from `level_uncached.psarc` must be included as well
 * Assets will be found in the inputted folder
 
 ## Notes
 
 * Including the `texstream.dat` file in the same place as `main.dat` will improve texture resolution (found in `level_textures.psarc`)
 * Including the `debug.dat` file for a level in the same place as `main.dat` will include asset and instance names
-
-## For Devs
-
-* use the arg `--load-ufrags` to enable the loading of ufrags

--- a/ReLunacy/Engine/AssetManager.cs
+++ b/ReLunacy/Engine/AssetManager.cs
@@ -101,6 +101,7 @@ public class AssetManager
         Mobys.Clear();
         Ties.Clear();
         UFrags.Clear();
+        Cube.transforms.Clear();
     }
 
     public void ConsolidateMobys()

--- a/ReLunacy/Engine/AssetManager.cs
+++ b/ReLunacy/Engine/AssetManager.cs
@@ -86,9 +86,9 @@ public class AssetManager
         {
             Ties.Add(tie.Key, new(tie.Value));
         }
-        foreach(var zoneUfrags in loader.zones)
+        foreach(var zone in loader.zones)
         {
-            foreach(var ufrag in zoneUfrags.Value.ufrags)
+            foreach(var ufrag in zone.Value.ufrags)
             {
                 UFrags.TryAdd(ufrag.GetTuid(), new(ufrag));
             }

--- a/ReLunacy/Engine/EntityManagement/Entity.cs
+++ b/ReLunacy/Engine/EntityManagement/Entity.cs
@@ -16,8 +16,6 @@ public class Entity
     //xyz is pos, w is radius
     public Vec4 boundingSphere;
 
-    public static uint drawCalls;
-
     public Entity(Region.CMobyInstance mobyInstance)
     {
         instance = mobyInstance;

--- a/ReLunacy/Engine/EntityManagement/EntityCluster.cs
+++ b/ReLunacy/Engine/EntityManagement/EntityCluster.cs
@@ -76,6 +76,11 @@ public class EntityCluster
         return true;
     }
 
+    public static void Wipe()
+    {
+        TotalEntities = 0;
+    }
+
     // FOR DEBUG PURPOSE
     public Drawable[] GetDrawables()
     {

--- a/ReLunacy/Engine/Rendering/Material.cs
+++ b/ReLunacy/Engine/Rendering/Material.cs
@@ -33,7 +33,7 @@ public class Material
     {
         asset = cshad;
         Texture? tex = cshad.albedo == null ? null : AssetManager.Singleton.Textures[cshad.albedo.id];
-        Texture? exp = cshad.expensive == null ? null : AssetManager.Singleton.Textures[cshad.expensive.id];
+        Texture? exp = cshad.expensive == null || Window.Singleton.FileManager.isOld ? null : AssetManager.Singleton.Textures[cshad.expensive.id];
         if (tex == null && cshad.albedo != null) Console.Error.WriteLine($"WARNING: FAILED TO FIND TEXTURE {cshad.albedo.id.ToString("X08")} AKA {cshad.albedo.name}");
         if (cshad.renderingMode != CShader.RenderingMode.AlphaBlend)
         {

--- a/ReLunacy/Program.cs
+++ b/ReLunacy/Program.cs
@@ -4,7 +4,7 @@ internal class Program
 {
     public const string AppName = "Lunacy_v2";
     public const string AppDisplayName = "ReLunacy";
-    public const string Version = "0.01";
+    public const string Version = "0.01.1";
     public static string ProvidedPath = "";
     public static string AppPath { get => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location); }
 

--- a/ReLunacy/Shaders/volumef.glsl
+++ b/ReLunacy/Shaders/volumef.glsl
@@ -9,5 +9,5 @@ uniform bool useTexture;
 
 void main()
 {
-	color = vec4(1, 1, 0, 0.5);
+	color = vec4(1, 1, 1, 1);
 }

--- a/ReLunacy/Utility/Overlay.cs
+++ b/ReLunacy/Utility/Overlay.cs
@@ -129,9 +129,7 @@ public class Overlay
                     float resx, resy;
                     resx = view3d.FrameContentSize.X;
                     resy = view3d.FrameContentSize.Y;
-                    ImGui.Text($"Resolution: {view3d.FrameContentSize}");
-                    ImGui.Text($"Region: {view3d.Region}");
-                    ImGui.Text($"Position: {view3d.FramePos}");
+                    ImGui.Text($"Resolution: ({resx}x{resy})");
                 }
                 ImGui.EndGroup();
             }

--- a/ReLunacy/Window.cs
+++ b/ReLunacy/Window.cs
@@ -68,6 +68,11 @@ public class Window : GameWindow
         io.ConfigFlags |= ImGuiConfigFlags.DockingEnable;
 
         AddFrame(new View3DFrame());
+
+        if(Program.ProvidedPath != string.Empty)
+        {
+            LoadLevelDataAsync(Program.ProvidedPath, new("Loading level...", new(0, 1)));
+        }
     }
 
     protected override void OnRenderFrame(FrameEventArgs eventArgs)
@@ -135,6 +140,7 @@ public class Window : GameWindow
         TryWipeLevel();
         AddFrame(loadingFrame);
         LunaLog.LogInfo($"Loading level {path.Split(Path.DirectorySeparatorChar)[^1]}.");
+        Program.ProvidedPath = path;
 
         FileManager = new();
         LunaLog.LogDebug("Starting FileManager threaded task.");
@@ -157,6 +163,7 @@ public class Window : GameWindow
             return;
 
         EntityManager.Singleton.Wipe();
+        EntityCluster.Wipe();
         AssetManager.Singleton.Wipe();
         AssetLoader = null;
         FileManager = null;


### PR DESCRIPTION
- Updated the Readme for better information sorta
- Added a counter for the loading of zones of the old engine because some levels have really, really lots of zones, resulting in a very long loading, so while I have no solution to speed up the loading, i'll keep it like that.
- Fixed previous level's volumes not clearing when loading a new level, resulting in a shitton of volumes visualized that had nothing to do there
- Fixed the "Total Entities" stats not clearing correctly when loading or closing a level, resulting in an always-growing number that does not reflect the true amount of entities the engine actually handles.
- Fixed old-engine expensive texture assignment; We still haven't reversed them afaik, so the level editor was crashing when loading old-engine levels as there's no expensive textures loaded in the database, despite having references to them.
- Fixed using commands to load levels on `ReLunacy.exe`: Previously, loading a level from a command argument when launching the level editor was not working, now it does.
- Changed the colour of volumes from yellowish to white.
- Removed debug leftovers on stats overlay.