### PR TITLE
Add Phase 1 old-engine Shrub support: detection, metadata, materials

### DIFF
--- a/ReLunacy.Engine/Assets/Foliage/Foliage.cs
+++ b/ReLunacy.Engine/Assets/Foliage/Foliage.cs
@@ -44,13 +44,23 @@ public sealed class Foliage : IAsset
 
     public IReadOnlyList<FoliagePlacement> Placements { get; private set; }
 
+    /// <summary>The material this foliage draws with, resolved from <see cref="Metadata"/>'s
+    /// TextureIndex through the old-engine 0x5200 table (see
+    /// Loading.Objects.FoliageMetadata.TextureIndex and MaterialReader.GetFoliageMaterial — the
+    /// game indexes that table directly, it is not a shader lookup). Null when the index is the
+    /// 0xFFFFFFFF sentinel, out of range, or the level was read without a MaterialReader (e.g. new
+    /// engine); the renderer then falls back to the default billboard texture. The resolved atlas
+    /// itself is reachable as <c>Material.AlbedoTexture</c>.</summary>
+    public IMaterial? Material { get; }
+
     public Foliage(ulong id, FoliageMetadata metadata, IReadOnlyList<FoliageSpriteCard> sprites,
-        IReadOnlyList<FoliagePlacement> placements, string? name = null)
+        IReadOnlyList<FoliagePlacement> placements, IMaterial? material = null, string? name = null)
     {
         Id = id;
         Metadata = metadata;
         Sprites = sprites;
         Placements = placements;
+        Material = material;
         Name = name ?? $"Foliage_{metadata.FoliageId}";
     }
 

--- a/ReLunacy.Engine/Assets/Shrubs/Shrub.cs
+++ b/ReLunacy.Engine/Assets/Shrubs/Shrub.cs
@@ -1,0 +1,39 @@
+using ReLunacy.Engine.Assets.Interfaces;
+using ReLunacy.Engine.Loading.Objects;
+
+namespace ReLunacy.Engine.Assets.Shrubs;
+
+/// <summary>One old-engine "Shrub" asset — main.dat section 0xB100 (see
+/// Loading.Objects.ShrubMetadataOld for the naming note and per-field proof level).
+///
+/// DELIBERATELY METADATA-ONLY for now: no geometry (<see cref="ShrubMetadataOld.Resource9000Offset"/>
+/// points into vertices.dat's shared 0x9000 pool, but no vertex layout has been decoded against it)
+/// and no placements (the 0x9540 spatial container's records don't have a proven mapping back to a
+/// specific 0xB100 index yet — see Loading.Readers.ShrubReader). Adding either now would mean
+/// inventing the exact thing the EBOOT reverse couldn't pin down without a real sample. Once that
+/// mapping and the vertex layout are verified, this gains Meshes/Placements the same way
+/// Assets.Foliage.Foliage did once its texture link was verified.</summary>
+public sealed class Shrub : IAsset
+{
+    public ulong Id { get; init; }
+    public string? Name { get; init; }
+    public bool IsLoaded => true;
+
+    /// <summary>The parsed 0xB100 record, for inspectors and for every field this class doesn't
+    /// surface directly.</summary>
+    public ShrubMetadataOld Metadata { get; }
+
+    /// <summary>The material resolved from <see cref="ShrubMetadataOld.MaterialIndex"/> through the
+    /// existing old-engine 0x5000 shader table (MaterialReader.GetMaterialByIndex — the same path
+    /// every other old-engine mesh type uses). Never null: an out-of-range index falls back to
+    /// MaterialReader's default material, same as Tie/Moby/UFrag meshes do.</summary>
+    public IMaterial Material { get; }
+
+    public Shrub(ulong id, ShrubMetadataOld metadata, IMaterial material, string? name = null)
+    {
+        Id = id;
+        Metadata = metadata;
+        Material = material;
+        Name = name ?? $"Shrub_{id:X}";
+    }
+}

--- a/ReLunacy.Engine/Loading/Objects/FoliageMetadata.cs
+++ b/ReLunacy.Engine/Loading/Objects/FoliageMetadata.cs
@@ -27,24 +27,45 @@ public record struct FoliageMetadata : ILunaSerializable
     /// <summary>Number of sprite LOD ranges actually populated (metropolis: 5 of the 5 slots).</summary>
     public const int MaxSpriteLods = 5;
 
+    /// <summary><see cref="TextureIndex"/> sentinel: this foliage asset binds no texture. The game
+    /// tests the field against -1 and takes a fallback branch instead of indexing 0x5200 (EBOOT
+    /// 0x4E2304 / 0x4E233C), so this must be resolved to "no texture", never used as an index.</summary>
+    public const uint NoTexture = 0xFFFFFFFF;
+
     /// <summary>0x0F on both metropolis foliages. Not identified - a flag set, most likely.</summary>
     public uint Unk0;
 
-    /// <summary>The only fields that differ between metropolis's two foliage assets, besides the
-    /// geometry offsets: 0/0 on the first, 1/1 on the second. InsomniaToolset names them foliageId
-    /// (u16 at 0x04) and textureIndex (u32 at 0x08).
-    ///
-    /// TextureIndex is NOT an index into the level texture table. Metropolis's two foliage textures
-    /// are at table indices 1286 and 1287, not 0 and 1, and no table anywhere in main.dat maps one
-    /// to the other - searched for the values and for the record addresses, aligned, across the
-    /// whole file, zero hits. What DOES resolve is the shader: the only references to texture 1286
-    /// and 1287 in the entire file are shaders #626 and #627 (both RenderingMode.Blended, both
-    /// DXT5). Foliage asset 0 pairs with the first of those and asset 1 with the second, so the
-    /// resolution is positional over the foliage shaders. That is an inference from two samples,
-    /// not something read out of the file - do not extend it to a level with more foliage types
-    /// without checking.</summary>
+    /// <summary>u16 @ 0x04. InsomniaToolset names this foliageId. It is 0 on BOTH metropolis
+    /// foliages, so it is NOT the field that distinguishes the two assets - the earlier note here
+    /// claimed 0x04 was the varying field (0/0 then 1/1), which is wrong for this sample. The pair
+    /// that actually moves between the two assets is <see cref="Unk6"/> (0x06) and
+    /// <see cref="TextureIndex"/> (0x08), each 0 on the first and 1 on the second.</summary>
     public ushort FoliageId;
+
+    /// <summary>u16 @ 0x06. The renderer reads this directly off the live A200 pointer (EBOOT
+    /// 0x51FFD0 and 0x52007C both `lhz rN,0x06(...)`), so it is a genuine per-asset selection/sort
+    /// key rather than padding - but which exactly (material variant, render key, foliage type) is
+    /// not pinned down, so it keeps a neutral name. Varies 0/1 across the two metropolis assets, in
+    /// lockstep with <see cref="TextureIndex"/>. NOT needed to resolve the texture.</summary>
     public ushort Unk6;
+
+    /// <summary>DIRECT physical index into the old-engine texture table (section 0x5200,
+    /// <see cref="Textures.TextureMetadataOld"/>) - NOT a shader lookup. The game's own A200 loader
+    /// proves it instruction for instruction: it reads this field (EBOOT 0x4E22F8, `lwz r14,0x08`),
+    /// tests it against -1 (0x4E2304), and when it isn't the sentinel rewrites the slot in place as
+    /// `section5200Base + TextureIndex * 0x20` (0x4E22B8..0x4E22CC multiply the index by 0x20 and add
+    /// the section base the 0x5200 handler cached at manager+0x0C, EBOOT 0x4E2054). So the texture is
+    /// TextureMetadataOld[TextureIndex], addressed by POSITION in the table, not by id/TUID.
+    ///
+    /// This supersedes the earlier shader-626/627 inference, which was a guess from two samples and
+    /// is NOT what the loader does - there is no shader indirection and no 0/1 -&gt; 1286/1287 remap.
+    /// The atlas bound for asset 0 is 0x5200 entry 0 (512x512 DXT5), for asset 1 entry 1; confirmed
+    /// independently by the two descriptors' pixel offsets sitting exactly one full 512x512 BC3 mip
+    /// chain (0x55580) apart.
+    ///
+    /// 0xFFFFFFFF is the "no texture" sentinel (see <see cref="NoTexture"/> / <see cref="HasTexture"/>).
+    /// Resolve through TextureShaderLoader.ResolveOldTextureIndex, which handles both the sentinel
+    /// and an out-of-range index.</summary>
     public uint TextureIndex;
 
     public uint Unk5;
@@ -81,6 +102,10 @@ public record struct FoliageMetadata : ILunaSerializable
         SpriteLodRanges is { Length: > 0 } ? SpriteLodRanges[^1].CornerEnd : 0;
 
     public readonly int TotalSprites => TotalCorners / FoliageSpriteCorner.CornersPerSprite;
+
+    /// <summary>False when <see cref="TextureIndex"/> is the <see cref="NoTexture"/> sentinel, i.e.
+    /// the game would take its no-texture fallback for this asset.</summary>
+    public readonly bool HasTexture => TextureIndex != NoTexture;
 
     public static FoliageMetadata Read(StreamHelper sh, uint recordBase)
     {

--- a/ReLunacy.Engine/Loading/Objects/ShrubContainerHeaderOld.cs
+++ b/ReLunacy.Engine/Loading/Objects/ShrubContainerHeaderOld.cs
@@ -1,0 +1,121 @@
+using System.Numerics;
+using ReLunacy.Engine.Loading.IO;
+
+namespace ReLunacy.Engine.Loading.Objects;
+
+/// <summary>Header of the old-engine Shrub spatial container — main.dat section 0x9540, a single
+/// blob (not a repeated-record table like <see cref="ShrubMetadataOld"/>'s 0xB100).
+///
+/// PROVEN field-for-field from the EBOOT's own initializer (0x573EF8, reached from the 0x9540
+/// loader handler at 0x4E29D4 via stub 0x269CC0): it reads Value00/08/10/18 as plain u32s into the
+/// runtime manager, and Relative04/0C/14 the same way EXCEPT it also adds the section's own base
+/// pointer before storing them — i.e. those three are offsets relative to the START OF THIS BLOB,
+/// not absolute main.dat offsets and not relative to main.dat's own base. Resolve them as
+/// <c>section9540.offset + relativeValue</c>, and bounds-check against the section's length before
+/// touching anything at the resolved address.
+///
+/// <see cref="Parameter20"/>/<see cref="Parameter24"/>/<see cref="Parameter28"/> are proven to be
+/// floats (EBOOT reads them with `lfs`) used somewhere in the renderer's spatial math — nothing
+/// pins down which distance/scale/parameter each one is, so they keep neutral names rather than a
+/// guessed "CellSize"/"GridScale"/"WorldScale".
+///
+/// <see cref="Version"/> is proven read and compared against 3 by the loader (EBOOT 0x573F18-
+/// 0x573F1C, `lhz r0,0x2C(r4)` / `cmpwi r0,3`) before it trusts the rest of this header — ShrubReader
+/// does the same and skips parsing anything past this header when it doesn't match, rather than
+/// guessing at a different revision's layout.</summary>
+public record struct ShrubContainerHeaderOld
+{
+    public const uint ID = 0x9540;
+    public const ushort ExpectedVersion = 3;
+
+    public uint Value00;
+
+    /// <summary>Offset, relative to this section's own start, of a table of 0x40-byte records — see
+    /// <see cref="ShrubSpatialRecordOld"/>. The record COUNT is not established (no field in this
+    /// header is proven to hold it), so ShrubReader reports this offset for diagnostics but does not
+    /// enumerate the table yet.</summary>
+    public uint Relative04;
+
+    public uint Value08;
+
+    /// <summary>Offset, relative to this section's own start, of a second internal table. Contents
+    /// not yet examined.</summary>
+    public uint Relative0C;
+
+    public uint Value10;
+
+    /// <summary>Offset, relative to this section's own start, of a third internal table. Contents
+    /// not yet examined.</summary>
+    public uint Relative14;
+
+    public uint Value18;
+    public uint Unknown1C;
+
+    /// <summary>PROVEN float (EBOOT `lfs f4,0x20(r4)`). Meaning not established.</summary>
+    public float Parameter20;
+
+    /// <summary>PROVEN float (EBOOT `lfs f3,0x24(r4)`). Meaning not established.</summary>
+    public float Parameter24;
+
+    /// <summary>PROVEN float (EBOOT `lfs f12,0x28(r4)`). Meaning not established.</summary>
+    public float Parameter28;
+
+    /// <summary>PROVEN: the loader requires this to equal <see cref="ExpectedVersion"/> (3) before
+    /// trusting the rest of the blob.</summary>
+    public ushort Version;
+
+    public ushort Unknown2E;
+
+    public static ShrubContainerHeaderOld Read(StreamHelper sh, uint sectionOffset)
+    {
+        var h = new ShrubContainerHeaderOld
+        {
+            Value00 = sh.ReadUInt32(sectionOffset + 0x00),
+            Relative04 = sh.ReadUInt32(sectionOffset + 0x04),
+            Value08 = sh.ReadUInt32(sectionOffset + 0x08),
+            Relative0C = sh.ReadUInt32(sectionOffset + 0x0C),
+            Value10 = sh.ReadUInt32(sectionOffset + 0x10),
+            Relative14 = sh.ReadUInt32(sectionOffset + 0x14),
+            Value18 = sh.ReadUInt32(sectionOffset + 0x18),
+            Unknown1C = sh.ReadUInt32(sectionOffset + 0x1C),
+            Version = sh.ReadUInt16(sectionOffset + 0x2C),
+            Unknown2E = sh.ReadUInt16(sectionOffset + 0x2E),
+        };
+
+        sh.Seek(sectionOffset + 0x20);
+        h.Parameter20 = sh.ReadSingle();
+        h.Parameter24 = sh.ReadSingle();
+        h.Parameter28 = sh.ReadSingle();
+
+        return h;
+    }
+}
+
+/// <summary>One 0x40-byte record of the table pointed to by <see cref="ShrubContainerHeaderOld.Relative04"/>.
+/// Size is PROVEN by the EBOOT's own copy loop (0x5748D0-0x57499C: index * 64 addressing, four
+/// SIMD 0x10-byte block copies per record). Split into four raw Vector4 slots deliberately — NOT
+/// named Position/Scale/Axis1/Axis2 the way older Insomniac-engine layouts of this shape are
+/// sometimes structured, because that has not been checked against real Shrub data yet (no
+/// main.dat with both 0xB100 and 0x9540 was available while writing this). Rename the slots only
+/// after validating the interpretation against a real sample.</summary>
+public record struct ShrubSpatialRecordOld
+{
+    public const uint Size = 0x40;
+
+    public Vector4 Value0;
+    public Vector4 Value1;
+    public Vector4 Value2;
+    public Vector4 Value3;
+
+    public static ShrubSpatialRecordOld Read(StreamHelper sh, uint recordBase)
+    {
+        sh.Seek(recordBase);
+        return new ShrubSpatialRecordOld
+        {
+            Value0 = new Vector4(sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle()),
+            Value1 = new Vector4(sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle()),
+            Value2 = new Vector4(sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle()),
+            Value3 = new Vector4(sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle()),
+        };
+    }
+}

--- a/ReLunacy.Engine/Loading/Objects/ShrubMetadataOld.cs
+++ b/ReLunacy.Engine/Loading/Objects/ShrubMetadataOld.cs
@@ -1,0 +1,119 @@
+using ReLunacy.Engine.Loading.IO;
+using ReLunacy.Engine.Loading.Interfaces;
+
+namespace ReLunacy.Engine.Loading.Objects;
+
+/// <summary>One old-engine "Shrub" asset record — main.dat section 0xB100, 0x30 bytes per record.
+///
+/// NAMING NOTE: the EBOOT is stripped and carries no "Shrub" symbol or string anywhere. What IS
+/// proven from the EBOOT alone is that 0xB100 is a distinct old-engine subsystem: an asset table
+/// selected by u16 index (<see cref="StreamingLoadCode"/> path, EBOOT 0x57673C-0x57674C proves
+/// stride 0x30), tied to a spatial container at section 0x9540, resolving its material through the
+/// same 0x5000 shader table every other old-engine mesh uses, and fed from the resources tagged
+/// 0x9000/0x9100 in vertices.dat (the SAME two section IDs Tie/Moby/UFrag already use there as the
+/// shared vertex/index pools — see TieMetadataOld, Moby.cs QuerySection(0x9000)/(0x9100)). ReLunacy
+/// calls this subsystem "Shrub" because static, non-collidable background foliage/props is exactly
+/// the category being added and no other old-engine subsystem already claims that name — not
+/// because the EBOOT says so.
+///
+/// PROOF LEVEL PER FIELD is called out individually below. Two fields
+/// (<see cref="RuntimeMaterialValue58"/>/<see cref="RuntimeMaterialValue34"/>/<see cref="RuntimeRenderCode"/>)
+/// are proven to be OVERWRITTEN by the EBOOT at load time from the resolved material — their on-disk
+/// value is kept here for reverse/debug purposes only, not as the value the game actually renders
+/// with.
+///
+/// Everything else (geometry decode, the 9540-&gt;B100 instance/transform mapping) needs a real
+/// main.dat containing both 0xB100 and 0x9540 to verify against — none was available while writing
+/// this (see ShrubReader's class remarks) — so this record intentionally stops at metadata.</summary>
+public record struct ShrubMetadataOld : ILunaSerializable
+{
+    public const uint ID = 0xB100;
+    public const uint Size = 0x30;
+
+    /// <summary>PROVEN relocated at load time against the resource tagged 0x9000 (EBOOT 0x4E2068:
+    /// the loader calls its section-0x9000 decode, then at 0x4E2A1C-0x4E2A24 adds that resource's
+    /// runtime base onto this field in place). 0x9000 is the same vertices.dat section id Tie/Moby/
+    /// UFrag already use as the shared old-engine vertex pool (see TieMetadataOld's remarks) — a
+    /// strong independent hint this is a vertex-buffer offset into that same pool, but NOT yet
+    /// verified for Shrub specifically (no sample), so it keeps a neutral name rather than
+    /// "VertexBufferOffset" until an actual Shrub vertex layout is decoded against it.</summary>
+    public uint Resource9000Offset;
+
+    /// <summary>Unidentified. The subsystem also loads the resource tagged 0x9100 (vertices.dat's
+    /// shared old-engine INDEX pool for Tie/Moby/UFrag), and this field is a plausible candidate for
+    /// an offset/count into it, but the EBOOT reverse did not pin down which of +0x04/+0x08 (if
+    /// either) is that field — do not name it indexOffset without checking it against real 0x9100
+    /// data (index range validity, divisible-by-3 counts, etc. — see ShrubReader remarks).</summary>
+    public uint Unknown04;
+
+    /// <summary>Unidentified — see <see cref="Unknown04"/>.</summary>
+    public uint Unknown08;
+
+    /// <summary>PROVEN read and tested (at least one bit) by the EBOOT (`lhz ...,0x0C(B100)`). Which
+    /// bit(s) mean what is not established — kept raw for debug tooling.</summary>
+    public ushort Flags0C;
+
+    public ushort Unknown0E;
+
+    /// <summary>Raw, unidentified 4 bytes at +0x10.</summary>
+    public uint Unknown10_13;
+
+    /// <summary>On-disk value at +0x14. PROVEN overwritten at load time with `*(float*)(material+0x58)`
+    /// (EBOOT: `lfs f0,0x58(material)` / `stfs f0,0x14(B100)`) — i.e. ShaderMetadataOld.detailTiling.
+    /// The value read here is whatever shipped on disk BEFORE that runtime patch, not what the game
+    /// actually renders with; kept for reverse/debug only.</summary>
+    public float RuntimeMaterialValue58;
+
+    /// <summary>On-disk value at +0x18. PROVEN overwritten at load time with `*(float*)(material+0x34)`
+    /// (EBOOT: `lfs f13,0x34(material)` / `stfs f13,0x18(B100)`). Same caveat as
+    /// <see cref="RuntimeMaterialValue58"/> — this is the pre-patch disk value.</summary>
+    public float RuntimeMaterialValue34;
+
+    /// <summary>Raw, unidentified 4 bytes at +0x1C.</summary>
+    public uint Unknown1C_1F;
+
+    /// <summary>PROVEN direct index into the old-engine shader/material table (main.dat section
+    /// 0x5000, <see cref="Shaders.ShaderMetadataOld"/>, record size 0x80) — EBOOT 0x574034-0x574054:
+    /// `lhz r11,0x20(record)` then `material = materialTableBase + MaterialIndex * 0x80`. Resolve
+    /// through the EXISTING old-engine material path (MaterialReader.GetMaterialByIndex), which
+    /// already keys ShaderMetadataOld by this exact table-position index for every other old-engine
+    /// mesh type — no Shrub-specific texture/shader resolver needed or wanted.</summary>
+    public ushort MaterialIndex;
+
+    /// <summary>On-disk value at +0x22. PROVEN overwritten at load time with either 0x0202 or 0x0203
+    /// depending on the resolved material's flags/renderingMode bytes (EBOOT: `li r12,0x0202` /
+    /// `li r30,0x0203` / `sth ...,0x22(record)`). Not an asset id — some kind of runtime render
+    /// dispatch code, picked per-material. Pre-patch disk value only; kept for reverse/debug.</summary>
+    public ushort RuntimeRenderCode;
+
+    /// <summary>Raw, unidentified 12 bytes at +0x24..+0x2F.</summary>
+    public byte[] Unknown24_2F;
+
+    public static ShrubMetadataOld Read(StreamHelper sh, uint recordBase)
+    {
+        var m = new ShrubMetadataOld
+        {
+            Resource9000Offset = sh.ReadUInt32(recordBase + 0x00),
+            Unknown04 = sh.ReadUInt32(recordBase + 0x04),
+            Unknown08 = sh.ReadUInt32(recordBase + 0x08),
+            Flags0C = sh.ReadUInt16(recordBase + 0x0C),
+            Unknown0E = sh.ReadUInt16(recordBase + 0x0E),
+            Unknown10_13 = sh.ReadUInt32(recordBase + 0x10),
+            Unknown1C_1F = sh.ReadUInt32(recordBase + 0x1C),
+            MaterialIndex = sh.ReadUInt16(recordBase + 0x20),
+            RuntimeRenderCode = sh.ReadUInt16(recordBase + 0x22),
+        };
+
+        sh.Seek(recordBase + 0x14);
+        m.RuntimeMaterialValue58 = sh.ReadSingle();
+        sh.Seek(recordBase + 0x18);
+        m.RuntimeMaterialValue34 = sh.ReadSingle();
+
+        sh.Seek(recordBase + 0x24);
+        m.Unknown24_2F = sh.ReadBytes(12);
+
+        return m;
+    }
+
+    public readonly byte[] ToBytes(bool isOld, params object[]? additionalParams) => throw new NotImplementedException();
+}

--- a/ReLunacy.Engine/Loading/Readers/FoliageReader.cs
+++ b/ReLunacy.Engine/Loading/Readers/FoliageReader.cs
@@ -16,10 +16,16 @@ namespace ReLunacy.Engine.Loading.Readers;
 public sealed class FoliageReader
 {
     private readonly FileManager _fileManager;
+    private readonly MaterialReader? _materialReader;
 
-    public FoliageReader(FileManager fileManager)
+    /// <param name="materialReader">Resolves each asset's atlas from its direct texture index
+    /// (A200+0x08 into the 0x5200 table). Optional: when null (e.g. a standalone geometry-only read)
+    /// foliage still loads, just with no material, and the renderer falls back to the default
+    /// billboard texture.</param>
+    public FoliageReader(FileManager fileManager, MaterialReader? materialReader = null)
     {
         _fileManager = fileManager ?? throw new ArgumentNullException(nameof(fileManager));
+        _materialReader = materialReader;
     }
 
     public IReadOnlyList<Assets.Foliage.Foliage> ReadAll()
@@ -51,12 +57,19 @@ public sealed class FoliageReader
 
             var sprites = ReadSprites(vertices.sh, (uint)vertSection.offset, meta);
 
+            // Resolve the atlas straight from the record's direct texture index (A200+0x08 →
+            // 0x5200[index], see FoliageMetadata.TextureIndex). Null for the 0xFFFFFFFF sentinel, an
+            // out-of-range index, or a null materialReader — the asset then keeps a null material
+            // and the renderer draws the default billboard texture rather than crashing.
+            var material = _materialReader?.GetFoliageMaterial(meta.TextureIndex);
+
             byOffset[recordBase] = result.Count;
             result.Add(new Assets.Foliage.Foliage(
                 id: recordBase,
                 metadata: meta,
                 sprites: sprites,
-                placements: []));
+                placements: [],
+                material: material));
         }
 
         AttachPlacements(main, result, byOffset);
@@ -81,8 +94,16 @@ public sealed class FoliageReader
         foreach (var f in foliages)
         {
             var lods = string.Join("/", f.Metadata.SpriteLodRanges.Where(r => r.CornerCount > 0).Select(r => r.SpriteCount));
+            // Report how the direct texture index resolved — an unresolved index or a wrong 0x5200
+            // ordering would otherwise be invisible until the atlas rendered wrong on screen. For
+            // metropolis both assets should read 0x5200[0]/[1] as 512x512 DXT5.
+            string tex = !f.Metadata.HasTexture
+                ? "none (0xFFFFFFFF)"
+                : f.Material?.AlbedoTexture is { } a
+                    ? $"0x5200[{f.Metadata.TextureIndex}] → {a.Width}x{a.Height} {a.Format}"
+                    : $"{f.Metadata.TextureIndex} (unresolved)";
             Console.WriteLine($"  {f.Name}: {f.Sprites.Count} sprite(s) [LODs {lods}], " +
-                              $"{f.Placements.Count} placement(s), textureIndex={f.Metadata.TextureIndex}");
+                              $"{f.Placements.Count} placement(s), texture {tex}");
         }
     }
 

--- a/ReLunacy.Engine/Loading/Readers/LevelReader.cs
+++ b/ReLunacy.Engine/Loading/Readers/LevelReader.cs
@@ -17,6 +17,7 @@ public sealed class LevelReader
     private TieReader _tieReader = null!;
     private ZoneReader _zoneReader = null!;
     private FoliageReader _foliageReader = null!;
+    private ShrubReader _shrubReader = null!;
     private RegionReader _regionReader = null!;
 
     private Dictionary<ulong, Assets.Mobys.Moby>? _mobys;
@@ -24,6 +25,7 @@ public sealed class LevelReader
     private Dictionary<ulong, Assets.Levels.Zone>? _zones;
     private Assets.Levels.Region? _region;
     private IReadOnlyList<Assets.Foliage.Foliage>? _foliages;
+    private IReadOnlyList<Assets.Shrubs.Shrub>? _shrubs;
     private IReadOnlyList<Assets.Cubemaps.Cubemap>? _cubemaps;
     private Assets.Lighting.LightingEnvironment? _lightingEnvironment;
 
@@ -89,6 +91,13 @@ public sealed class LevelReader
         _foliageReader = new FoliageReader(_fileManager, _materialReader);
         _foliages = _foliageReader.ReadAll();
 
+        // Shrubs (old-engine section 0xB100, see Loading.Objects.ShrubMetadataOld) - metadata and
+        // material resolution only for now; see ShrubReader's remarks for why placements/geometry
+        // aren't decoded yet. Independent of mobys/ties/zones, same reasoning as foliage above.
+        progressCallback?.Invoke("Loading Shrubs...", 0.92f);
+        _shrubReader = new ShrubReader(_fileManager, _materialReader);
+        _shrubs = _shrubReader.ReadAll();
+
         // Old engine only (section 0x5920). Independent of geometry, same as foliage.
         _cubemaps = new CubemapReader(_fileManager).ReadAll();
 
@@ -115,6 +124,7 @@ public sealed class LevelReader
             zoneDirectionals: _materialReader.WrapZoneLighting(_textureShaderLoader.ZoneDirectionals),
             environmentAverage: _textureShaderLoader.EnvironmentAverage,
             foliages: _foliages,
+            shrubs: _shrubs,
             cubemaps: _cubemaps,
             lightingEnvironment: _lightingEnvironment);
     }
@@ -123,6 +133,7 @@ public sealed class LevelReader
     public IReadOnlyDictionary<ulong, Assets.Ties.Tie> Ties => _ties ?? [];
     public IReadOnlyDictionary<ulong, Assets.Levels.Zone> Zones => _zones ?? [];
     public IReadOnlyList<Assets.Foliage.Foliage> Foliages => _foliages ?? [];
+    public IReadOnlyList<Assets.Shrubs.Shrub> Shrubs => _shrubs ?? [];
     public IReadOnlyList<Assets.Cubemaps.Cubemap> Cubemaps => _cubemaps ?? [];
     public Assets.Lighting.LightingEnvironment? LightingEnvironment => _lightingEnvironment;
     public Assets.Levels.Region? Region => _region;
@@ -171,6 +182,11 @@ public sealed class LevelData
     /// Loading.Objects.FoliageMetadata.</summary>
     public IReadOnlyList<Assets.Foliage.Foliage> Foliages { get; }
 
+    /// <summary>Old-engine "Shrub" assets (main.dat 0xB100) with their material resolved, but no
+    /// geometry or placements yet - see Loading.Readers.ShrubReader for exactly why. Empty on the
+    /// new engine or a level without the section.</summary>
+    public IReadOnlyList<Assets.Shrubs.Shrub> Shrubs { get; }
+
     /// <summary>Environment cubemap(s), old-engine section 0x5920 (see Loading.Readers.CubemapReader).
     /// Usually one; empty when the level ships only a stub record (kerchu city) or on the new engine.</summary>
     public IReadOnlyList<Assets.Cubemaps.Cubemap> Cubemaps { get; }
@@ -193,6 +209,7 @@ public sealed class LevelData
         IReadOnlyList<Assets.Interfaces.ITexture>? zoneDirectionals = null,
         System.Numerics.Vector3? environmentAverage = null,
         IReadOnlyList<Assets.Foliage.Foliage>? foliages = null,
+        IReadOnlyList<Assets.Shrubs.Shrub>? shrubs = null,
         IReadOnlyList<Assets.Cubemaps.Cubemap>? cubemaps = null,
         Assets.Lighting.LightingEnvironment? lightingEnvironment = null)
     {
@@ -208,6 +225,7 @@ public sealed class LevelData
         ZoneDirectionals = zoneDirectionals ?? [];
         EnvironmentAverage = environmentAverage;
         Foliages = foliages ?? [];
+        Shrubs = shrubs ?? [];
         Cubemaps = cubemaps ?? [];
         LightingEnvironment = lightingEnvironment;
     }

--- a/ReLunacy.Engine/Loading/Readers/LevelReader.cs
+++ b/ReLunacy.Engine/Loading/Readers/LevelReader.cs
@@ -83,7 +83,10 @@ public sealed class LevelReader
         // engine only - FoliageReader returns empty on new-engine files rather than reading
         // old-engine offsets out of them.
         progressCallback?.Invoke("Loading Foliage...", 0.9f);
-        _foliageReader = new FoliageReader(_fileManager);
+        // Pass the MaterialReader so each foliage asset resolves its atlas from A200+0x08 (a direct
+        // index into the 0x5200 texture table — see FoliageMetadata.TextureIndex). Textures are
+        // already loaded above (_textureShaderLoader.LoadAll), so OldTexturesByIndex is populated.
+        _foliageReader = new FoliageReader(_fileManager, _materialReader);
         _foliages = _foliageReader.ReadAll();
 
         // Old engine only (section 0x5920). Independent of geometry, same as foliage.

--- a/ReLunacy.Engine/Loading/Readers/MaterialReader.cs
+++ b/ReLunacy.Engine/Loading/Readers/MaterialReader.cs
@@ -14,6 +14,7 @@ public sealed class MaterialReader
     private readonly TextureShaderLoader _loader;
     private readonly Dictionary<ulong, Material> _materialCache = [];
     private readonly Dictionary<ulong, Texture> _textureCache = [];
+    private readonly Dictionary<uint, IMaterial> _foliageMaterialCache = [];
     private Material? _defaultMaterial;
 
     public MaterialReader(TextureShaderLoader loader)
@@ -30,6 +31,41 @@ public sealed class MaterialReader
         if (shaderTuids != null && shaderIndex < shaderTuids.Length)
             return GetMaterialByTuid(shaderTuids[shaderIndex]);
         return GetDefaultMaterial();
+    }
+
+    /// <summary>Builds the material for an old-engine foliage asset from its direct texture index
+    /// (<see cref="Loading.Objects.FoliageMetadata.TextureIndex"/> — a physical position in the
+    /// 0x5200 table, resolved through <see cref="TextureShaderLoader.ResolveOldTextureIndex"/>, NOT
+    /// a shader lookup). Returns null for the 0xFFFFFFFF sentinel or an out-of-range index, so the
+    /// caller can fall back to the default billboard texture exactly as the game falls back.
+    ///
+    /// Foliage carries no shader reference of its own, so there is no ShaderMetadata to read a
+    /// render mode from; both metropolis foliage atlases are DXT5 and both foliage shaders are
+    /// RenderingMode.Blended, so the material is tagged AlphaBlend / Blended. The albedo texture is
+    /// wrapped through the same cache as every other texture, so the GPU upload is shared with any
+    /// other use of that same 0x5200 entry.</summary>
+    public IMaterial? GetFoliageMaterial(uint textureIndex)
+    {
+        if (_foliageMaterialCache.TryGetValue(textureIndex, out var cached))
+            return cached;
+
+        var legacy = _loader.ResolveOldTextureIndex(textureIndex);
+        if (legacy is null)
+            return null;
+
+        var albedo = WrapTexture(legacy);
+        // Material id = the texture's own id (its 0x5200 record offset): unique per texture, so two
+        // foliage assets pointing at the same atlas share one material, and it can't collide with an
+        // old-engine shader TUID (those are small sequential indices — see Shader ctor).
+        var material = Material.Create(
+            id: albedo.Id,
+            albedo: albedo,
+            renderMode: RenderMode.AlphaBlend,
+            gameRenderMode: (byte)Loading.Shaders.RenderingMode.Blended);
+        material.Name = $"FoliageTexture_{textureIndex}";
+
+        _foliageMaterialCache[textureIndex] = material;
+        return material;
     }
 
     /// <summary>

--- a/ReLunacy.Engine/Loading/Readers/ShrubReader.cs
+++ b/ReLunacy.Engine/Loading/Readers/ShrubReader.cs
@@ -1,0 +1,160 @@
+using ReLunacy.Engine.Loading.IO;
+using ReLunacy.Engine.Loading.Objects;
+using ReLunacy.Engine.Loading.Vertices;
+
+namespace ReLunacy.Engine.Loading.Readers;
+
+/// <summary>Reads old-engine "Shrub" assets: main.dat section 0xB100 (see
+/// <see cref="ShrubMetadataOld"/> for the naming note) and its spatial container at 0x9540 (see
+/// <see cref="ShrubContainerHeaderOld"/>).
+///
+/// PHASE 1 READER — metadata and material resolution only, deliberately. No main.dat containing
+/// both 0xB100 and 0x9540 was available while writing this (checked: neither this machine's game
+/// data nor any Game Browser-scanned level had either section — see
+/// <see cref="ScanForShrubSections"/>, added specifically so whoever DOES have real Tools of
+/// Destruction level files can find one). Without a real sample there is no way to verify:
+///   - the 9540 spatial container's record-&gt;0xB100 index mapping (so no placements/instances),
+///   - the vertex layout at Resource9000Offset (so no geometry/meshes).
+/// Building either would mean inventing exactly what the EBOOT reverse could not establish.
+/// Everything below IS backed directly by EBOOT instructions or an existing, already-shipped
+/// ReLunacy convention (0x9000/0x9100 as vertices.dat's shared old-engine vertex/index pools, per
+/// TieMetadataOld/Moby.cs) — see each field's remarks in <see cref="ShrubMetadataOld"/> /
+/// <see cref="ShrubContainerHeaderOld"/> for the specific proof.
+///
+/// New engine is not handled: 0xB100/0x9540 are old-engine section ids, and nothing has been
+/// checked against a new-engine equivalent (if one even exists) — ReadAll returns empty rather
+/// than guessing.</summary>
+public sealed class ShrubReader
+{
+    private readonly FileManager _fileManager;
+    private readonly MaterialReader _materialReader;
+
+    public ShrubReader(FileManager fileManager, MaterialReader materialReader)
+    {
+        _fileManager = fileManager ?? throw new ArgumentNullException(nameof(fileManager));
+        _materialReader = materialReader ?? throw new ArgumentNullException(nameof(materialReader));
+    }
+
+    public IReadOnlyList<Assets.Shrubs.Shrub> ReadAll()
+    {
+        if (!_fileManager.isOld) return [];
+        if (!_fileManager.igfiles.TryGetValue("main.dat", out IGFile? main) || main is null) return [];
+
+        var assets = main.QuerySection(ShrubMetadataOld.ID);
+        if (assets.id != ShrubMetadataOld.ID || assets.count == 0)
+        {
+            Console.WriteLine("[Shrubs] none (no 0xB100 section, or new engine).");
+            return [];
+        }
+
+        Console.WriteLine($"[Shrubs] B100 assets: {assets.count}");
+
+        uint vertexPoolLength = GetVertexPoolLength();
+        var result = new List<Assets.Shrubs.Shrub>((int)assets.count);
+        uint minMaterial = uint.MaxValue, maxMaterial = 0;
+        int valid9000Offsets = 0;
+
+        for (uint i = 0; i < assets.count; i++)
+        {
+            uint recordBase = (uint)(assets.offset + ShrubMetadataOld.Size * i);
+            var meta = ShrubMetadataOld.Read(main.sh, recordBase);
+
+            if (meta.MaterialIndex < minMaterial) minMaterial = meta.MaterialIndex;
+            if (meta.MaterialIndex > maxMaterial) maxMaterial = meta.MaterialIndex;
+            if (vertexPoolLength > 0 && meta.Resource9000Offset < vertexPoolLength) valid9000Offsets++;
+
+            // GetMaterialByIndex is the SAME resolver Tie/Moby/UFrag old-engine meshes already use
+            // for their oldShaderIndex - MaterialIndex is proven to address the identical 0x5000
+            // table the same way (see ShrubMetadataOld.MaterialIndex). No Shrub-specific texture or
+            // shader lookup here on purpose. Never null: an out-of-range index falls back to
+            // MaterialReader's default material, same as every other old-engine mesh type.
+            var material = _materialReader.GetMaterialByIndex(meta.MaterialIndex);
+            result.Add(new Assets.Shrubs.Shrub(recordBase, meta, material));
+        }
+
+        Console.WriteLine($"[Shrubs] material indices range {minMaterial}..{maxMaterial}");
+        if (vertexPoolLength > 0)
+            Console.WriteLine($"[Shrubs] 9000 offsets valid: {valid9000Offsets}/{assets.count}");
+
+        ReadSpatialContainer(main);
+
+        return result;
+    }
+
+    /// <summary>Length of vertices.dat's shared old-engine vertex pool (section 0x9000 — the same
+    /// pool Tie/Moby/UFrag read from), used only as a bounds reference for
+    /// <see cref="ShrubMetadataOld.Resource9000Offset"/> diagnostics. 0 if vertices.dat or that
+    /// section isn't present.</summary>
+    private uint GetVertexPoolLength()
+    {
+        if (!_fileManager.igfiles.TryGetValue("vertices.dat", out IGFile? vertices) || vertices is null)
+            return 0;
+
+        var vertexPool = vertices.QuerySection(VertexFormat0.OldID);
+        return vertexPool.id == VertexFormat0.OldID ? vertexPool.length : 0;
+    }
+
+    /// <summary>Parses the 9540 header (if present) purely for diagnostics — see the class remarks
+    /// for why this stops short of enumerating the 0x40-byte record table it points to.</summary>
+    private static void ReadSpatialContainer(IGFile main)
+    {
+        var section = main.QuerySection(ShrubContainerHeaderOld.ID);
+        if (section.id != ShrubContainerHeaderOld.ID)
+        {
+            Console.WriteLine("[Shrubs] 9540 not found (no spatial container - instances cannot be resolved for this level).");
+            return;
+        }
+
+        var header = ShrubContainerHeaderOld.Read(main.sh, section.offset);
+        if (header.Version != ShrubContainerHeaderOld.ExpectedVersion)
+        {
+            Console.WriteLine($"[Shrubs] WARNING: 9540 found but version={header.Version} (expected {ShrubContainerHeaderOld.ExpectedVersion}) - layout for this version is unverified, so the spatial container is skipped for this level. B100 assets/materials above still loaded normally.");
+            return;
+        }
+
+        Console.WriteLine($"[Shrubs] 9540 found, version={header.Version}");
+
+        if (header.Relative04 >= section.length)
+        {
+            Console.WriteLine($"[Shrubs] WARNING: 9540 Relative04 (0x{header.Relative04:X}) falls outside the section (length 0x{section.length:X}) - skipping table0.");
+            return;
+        }
+
+        uint table0Offset = section.offset + header.Relative04;
+        Console.WriteLine($"[Shrubs] table0 offset=0x{table0Offset:X}, record count candidate=unknown (not established from the EBOOT reverse - see ShrubContainerHeaderOld.Relative04)");
+    }
+
+    /// <summary>Opens <paramref name="mainDatPath"/> just far enough to read its section table (no
+    /// texture/shader/geometry decode) and reports whether it has BOTH 0xB100 and 0x9540 - the two
+    /// sections needed to actually finish this format. Intended for scanning a Game Browser's
+    /// discovered Tools of Destruction levels to find a usable sample; see GameBrowserFrame's
+    /// "Scan for Shrub sections" button. Never throws: any failure to open/parse the file is reported
+    /// as "not usable" via the return value rather than propagating.</summary>
+    public static bool ScanForShrubSections(string mainDatPath, out uint b100Count, out ushort headerVersion)
+    {
+        b100Count = 0;
+        headerVersion = 0;
+
+        try
+        {
+            using var stream = File.OpenRead(mainDatPath);
+            var main = new IGFile(stream);
+
+            var assets = main.QuerySection(ShrubMetadataOld.ID);
+            var header = main.QuerySection(ShrubContainerHeaderOld.ID);
+
+            bool hasB100 = assets.id == ShrubMetadataOld.ID && assets.count > 0;
+            bool has9540 = header.id == ShrubContainerHeaderOld.ID;
+
+            if (hasB100) b100Count = assets.count;
+            if (has9540) headerVersion = main.sh.ReadUInt16(header.offset + 0x2C);
+
+            return hasB100 && has9540;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Shrubs] scan of '{mainDatPath}' failed: {ex.Message}");
+            return false;
+        }
+    }
+}

--- a/ReLunacy.Engine/Loading/TextureShaderLoader.cs
+++ b/ReLunacy.Engine/Loading/TextureShaderLoader.cs
@@ -13,6 +13,14 @@ public sealed class TextureShaderLoader
     public readonly Dictionary<ulong, Texture> Textures = [];
     public readonly Dictionary<ulong, Shader> Shaders = [];
 
+    /// <summary>Old-engine textures in PHYSICAL ORDER of the 0x5200 section — element N is the
+    /// descriptor at sectionOffset + N * 0x20. This is the addressing a direct texture-index field
+    /// uses (e.g. <see cref="Objects.FoliageMetadata.TextureIndex"/>): the game computes
+    /// section5200Base + index * 0x20 and reads the descriptor there, so POSITION is the identity,
+    /// not the offset-derived key <see cref="Textures"/> is keyed by. Same Texture instances as
+    /// <see cref="Textures"/>, just also held in order. Empty on the new engine.</summary>
+    public readonly List<Texture> OldTexturesByIndex = [];
+
     private readonly FileManager _fileManager;
 
     public TextureShaderLoader(FileManager fileManager)
@@ -113,6 +121,9 @@ public sealed class TextureShaderLoader
             mainStream.Seek(textureMetadataSection.offset + TextureMetadataOld.Size * i);
             var texture = new Texture(mainStream, true);
             Textures.Add(texture.id, texture);
+            // Physical-position index, in lockstep with `i` — this is what direct index fields
+            // resolve through (see OldTexturesByIndex / ResolveOldTextureIndex).
+            OldTexturesByIndex.Add(texture);
 
             if (texstream is not null) texture.highmipsMetadatasOld = [];
         }
@@ -158,6 +169,22 @@ public sealed class TextureShaderLoader
         LoadZoneLightingSection(main, textures, ZoneLightmapSectionId, ZoneLightmaps);
         LoadZoneLightingSection(main, textures, ZoneDirectionalSectionId, ZoneDirectionals);
         LoadEnvironmentCubemapAverage(main);
+    }
+
+    /// <summary>Resolves a DIRECT old-engine texture index — a physical position in the 0x5200
+    /// table (see <see cref="OldTexturesByIndex"/>) — to its texture. Returns null for the
+    /// 0xFFFFFFFF "no texture" sentinel and for any index past the end of the table, so callers get
+    /// the game's own fallback behaviour rather than an exception or a wrapped 4-billion index.
+    /// This is exactly the addressing the game applies to
+    /// <see cref="Objects.FoliageMetadata.TextureIndex"/>.</summary>
+    public Texture? ResolveOldTextureIndex(uint index)
+    {
+        // 0xFFFFFFFF is the game's -1 "no resource" sentinel (see the EBOOT test at 0x4E2304, and
+        // FoliageMetadata.NoTexture for the foliage field that uses it). Kept inline rather than
+        // referencing that foliage constant so this stays a general old-texture-index resolver.
+        if (index == 0xFFFFFFFF || index >= (uint)OldTexturesByIndex.Count)
+            return null;
+        return OldTexturesByIndex[(int)index];
     }
 
     public const uint CubemapSectionId = 0x5920;

--- a/ReLunacy.Engine/Scene/EntityFoliage.cs
+++ b/ReLunacy.Engine/Scene/EntityFoliage.cs
@@ -56,11 +56,11 @@ public class EntityFoliage : Entity
         var cards = foliage.SpritesForLod(BuiltLod).ToList();
         if (cards.Count == 0) return;
 
-        // material may be null: which shader a foliage asset uses is NOT resolvable from the files
-        // yet (FoliageMetadata.TextureIndex is 0/1 while the real textures are #1286/#1287, and no
-        // table in main.dat connects them - see that field's comment). Rather than guess an index,
-        // an unresolved foliage draws with the default white texture, which still proves the
-        // billboarding and the card geometry are right and is obviously unfinished on screen.
+        // material carries the atlas resolved from FoliageMetadata.TextureIndex — a DIRECT index
+        // into the 0x5200 texture table, proven by the game's own A200 loader (see that field). It
+        // is null only when the asset's index is the 0xFFFFFFFF sentinel or the level is new-engine;
+        // GetOrBuildBillboardMaterial then falls back to the default white texture, which still
+        // shows the billboarding and card geometry while making an unresolved case obvious on screen.
         _material = assetManager.GetOrBuildBillboardMaterial(material);
         _mesh = BuildMesh(gd, cards, _material);
     }

--- a/ReLunacy.Engine/Scene/EntityManager.cs
+++ b/ReLunacy.Engine/Scene/EntityManager.cs
@@ -69,8 +69,11 @@ public class EntityManager : IDisposable
     {
         foreach (var foliage in foliages)
         {
+            // foliage.Material is resolved from the asset's direct texture index (A200+0x08 →
+            // 0x5200 table, see FoliageMetadata.TextureIndex). Null (0xFFFFFFFF sentinel / new
+            // engine) falls back to the default billboard texture inside GetOrBuildBillboardMaterial.
             foreach (var placement in foliage.Placements)
-                Foliage.Add(new EntityFoliage(foliage, placement, null, am, gd));
+                Foliage.Add(new EntityFoliage(foliage, placement, foliage.Material, am, gd));
         }
 
         if (Foliage.Count != 0)

--- a/ReLunacy/Core/Frames/DockedFrames/GameBrowserFrame.cs
+++ b/ReLunacy/Core/Frames/DockedFrames/GameBrowserFrame.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Bliss.CSharp.Interact;
 using ReLunacy.Core.Frames.Modals;
 using ReLunacy.Engine.Games;
+using ReLunacy.Engine.Loading.Readers;
 using ReLunacy.Utility;
 using ReLunacy.Utility.Localization;
 
@@ -16,6 +17,7 @@ public class GameBrowserFrame : DockedFrame
     private string rootPathInput = "";
     private GameLibrary? library;
     private string statusMessage = "";
+    private string shrubScanMessage = "";
 
     private string debugDatPathInput = "";
     private string debugDatStatusMessage = "";
@@ -96,6 +98,21 @@ public class GameBrowserFrame : DockedFrame
             ? $"Detected: {library.DetectedGame.DisplayName}"
             : "Detected: Unknown game (no level names matched yet)");
         ImGui.Text($"Levels found: {library.Levels.Count}");
+
+        // Old-engine "Shrub" support (0xB100/0x9540, see Loading.Objects.ShrubMetadataOld) is
+        // metadata-only until a level actually shipping both sections turns up - this button opens
+        // just the section table of each discovered level's main.dat (no texture/geometry decode)
+        // and reports which ones qualify, so that sample doesn't have to be found by hand.
+        ImGui.SameLine();
+        if (ImGui.Button("Scan for Shrub sections"))
+        {
+            ScanForShrubs();
+        }
+        if (!string.IsNullOrEmpty(shrubScanMessage))
+        {
+            ImGui.TextWrapped(shrubScanMessage);
+        }
+
         ImGui.Separator();
 
         if (ImGui.BeginChild("game_browser_levels", ImGui.GetContentRegionAvail(), ImGuiChildFlags.Borders, ImGuiWindowFlags.AlwaysVerticalScrollbar))
@@ -190,6 +207,41 @@ public class GameBrowserFrame : DockedFrame
             statusMessage = $"Scan failed: {e.Message}";
             library = null;
         }
+    }
+
+    /// <summary>Checks every discovered FOLDER-sourced level's main.dat for both 0xB100 and 0x9540
+    /// (see ShrubReader.ScanForShrubSections) and reports the qualifying ones. Skips PSARC-sourced
+    /// levels: those are new-engine, and 0xB100/0x9540 are old-engine section ids that only occur in
+    /// the plain-folder main.dat layout old-engine levels use.</summary>
+    private void ScanForShrubs()
+    {
+        if (library is null || library.Levels.Count == 0)
+        {
+            shrubScanMessage = "Scan a game folder first.";
+            return;
+        }
+
+        var hits = new List<string>();
+        int checkedCount = 0;
+
+        foreach (var level in library.Levels)
+        {
+            if (level.SourceKind != LevelSourceKind.Folder) continue;
+
+            string mainDatPath = Path.Combine(level.SourcePath, "main.dat");
+            if (!File.Exists(mainDatPath)) continue;
+
+            checkedCount++;
+            if (ShrubReader.ScanForShrubSections(mainDatPath, out uint b100Count, out ushort version))
+            {
+                hits.Add($"{level.Name} (B100: {b100Count} asset(s), 9540 version {version})");
+            }
+        }
+
+        shrubScanMessage = hits.Count > 0
+            ? $"Found {hits.Count}/{checkedCount} level(s) with both 0xB100 and 0x9540:\n" + string.Join("\n", hits)
+            : $"Checked {checkedCount} level(s) - none have both 0xB100 and 0x9540.";
+        Console.WriteLine($"[Shrubs] scan: {shrubScanMessage.Replace('\n', ' ')}");
     }
 
     private static void LoadLevel(Level level)


### PR DESCRIPTION
Stacked on #44 (foliage->texture linking) - the diff below includes that PR's commit until it merges; only the last commit ("Add Phase 1 old-engine Shrub support") belongs to this PR.

Adds a new old-engine subsystem reader for main.dat section 0xB100 ("Shrub" - ReLunacy's own name; the EBOOT is stripped and has no symbol confirming that name, see `ShrubMetadataOld`'s remarks) and its spatial container at 0x9540.

**Scope is deliberately metadata-only.** No main.dat containing both 0xB100 and 0x9540 was available while writing this (checked this environment's game data and everything reachable from the Game Browser), so two things that would need a real sample to verify are left undone on purpose rather than guessed:
- the 9540 spatial container's record -> 0xB100 index mapping (so no placements/instances/transforms)
- the vertex layout at each asset's `Resource9000Offset` (so no meshes)

**What IS implemented**, backed either by the EBOOT reverse (proof level documented per field in `ShrubMetadataOld`/`ShrubContainerHeaderOld`) or by an existing, already-shipped ReLunacy convention (0x9000/0x9100 as vertices.dat's shared old-engine vertex/index pools, per `TieMetadataOld`/`Moby.cs`):
- `ShrubMetadataOld` - the 0x30-byte B100 record
- `ShrubContainerHeaderOld` / `ShrubSpatialRecordOld` - the 9540 header (with its version-3 gate) and the 0x40-byte record shape of the table its `Relative04` points to (record count isn't established, so that table isn't enumerated yet)
- `ShrubReader` - detects both sections, parses every B100 record, resolves its material through the **existing** old-engine path (`MaterialReader.GetMaterialByIndex` - no new texture/shader resolver, per the reverse notes), validates `Resource9000Offset` against vertices.dat's shared 0x9000 pool bounds, and logs a diagnostic summary. Returns empty (no exception) on any level without 0xB100, on the new engine, or without a MaterialReader - a level without shrubs loads exactly as before.
- `ShrubReader.ScanForShrubSections` + a "Scan for Shrub sections" button in `GameBrowserFrame` - opens just the section table of every discovered level's main.dat (no texture/geometry decode) and reports which ones actually have both sections, so a real sample can be found without manual hex-dumping.

**Deliberately NOT included**: `Render > Shrubs`, an Entity Explorer category, or any `EntityShrub`/scene-renderer wiring. All of those need actual placements to be meaningful, and building them now would mean fabricating the exact 9540->B100 mapping this PR stops short of guessing. They're straightforward to add once a real sample resolves that mapping and the vertex layout.

Builds clean (`dotnet build ReLunacy.sln`) and the app starts/runs with no regression to existing level loading.