### PR TITLE
Migrate off Veldrith onto NeoVeldrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ performance improvements thanks to that. For more details, see under !
   - Frame pipelining: CPU recording and GPU execution now overlap across frames, instead of the CPU immediately waiting on the previous frame's fence right after submitting it
   - Unified viewport input handling (which of the overlay/gizmo/picking/camera gets a click) across the 3D View and Asset Viewer
   - Fixed a large Tie frustum-culling error that could clip visible geometry at the edges of the screen
+  - Migrated off Veldrith (a single-maintainer Veldrid fork) onto NeoVeldrid, the actively-maintained Silk.NET-based continuation, so the project no longer depends on a custom graphics backend
 - Added a better `Frame Profiler` frame (performances debug)
 - Added `Level Data` frame (including instances count, assets count, and light sources)
 - Added an in-app Markdown renderer, used to show this changelog straight from the Update Info frame
@@ -45,6 +46,7 @@ performance improvements thanks to that. For more details, see under !
 - Fixed GPU buffer picking (clicking to select in the 3D View) silently not working, due to an input event-ordering bug
 - Fixed Moby Cull Distance and Update Distance being read from swapped file offsets
 - Fixed `3D View` being reset when closed and reopened.
+- Fixed the 3D scene renderer segfaulting on construction after the NeoVeldrid migration, from a Vulkan function-pointer table that was never explicitly initialized (previously only worked by accident, as a side effect of Veldrith initializing the same shared state internally)
 
 ## [v0.04.1](https://github.com/VELD-Dev/ReLunacy/releases/0.04.1) - 30-07-2026
 

--- a/ReLunacy.Engine/Diagnostics/FrameProfiler.cs
+++ b/ReLunacy.Engine/Diagnostics/FrameProfiler.cs
@@ -7,7 +7,7 @@ namespace ReLunacy.Engine.Diagnostics;
 /// stall, present, or any other pass. Lives in ReLunacy.Engine (not the app) so engine-side render
 /// code - the forward renderer especially - can self-instrument the passes it owns.
 ///
-/// It is a CPU profiler by design: Veldrith (the Veldrid fork this project uses) exposes no GPU
+/// It is a CPU profiler by design: NeoVeldrid (the Veldrid fork this project uses) exposes no GPU
 /// timestamp query pool, so there is no in-API way to read how long the GPU itself spent on a pass.
 /// What CAN be measured precisely is the CPU cost of building and submitting command lists, and -
 /// because the app calls WaitForIdle() once per frame - the time the CPU sits BLOCKED waiting for

--- a/ReLunacy.Engine/ReLunacy.Engine.csproj
+++ b/ReLunacy.Engine/ReLunacy.Engine.csproj
@@ -15,12 +15,25 @@
     <PackageReference Include="StbImageSharp" Version="2.30.15" />
     <PackageReference Include="StbImageWriteSharp" Version="1.16.7" />
     <PackageReference Include="TinyBCSharp" Version="0.1.2" />
-    <PackageReference Include="Veldrith" Version="1.2.19" />
+    <!-- Was Veldrith (Stellution-Studios), a single-maintainer fork - moved to NeoVeldrid, the
+         actively-maintained Silk.NET-based continuation of Veldrid, so the project doesn't depend on
+         a custom/niche fork. Drops the Direct3D12/Metal backends Veldrith added (see EditorWindow.cs
+         and EditorSettings.GraphicsBackend) - the raw-Vulkan scene renderer only ever worked on
+         Vulkan anyway (VulkanContext throws if GetVulkanInfo fails), so those paths never produced a
+         working 3D view regardless of backend. -->
+    <PackageReference Include="NeoVeldrid" Version="1.2.1" />
     <!-- GLSL to SPIR-V for the renderer's own shaders. Came in transitively through Bliss. -->
-    <PackageReference Include="Veldrith.SPIRV" Version="1.2.19" />
-    <!-- Raw Vulkan for the new from-scratch renderer (Docs/NewRenderer.md). Pinned to exactly the
-         version Veldrith uses so the handles GraphicsDevice.GetVulkanInfo() returns are the same
-         Vortice types we consume. -->
+    <PackageReference Include="NeoVeldrid.SPIRV" Version="1.2.1" />
+    <!-- NeoVeldrid.SPIRV only references the managed Silk.NET.Shaderc/Silk.NET.SPIRV.Cross bindings,
+         not their native libraries - Silk.NET splits those into separate opt-in packages. Without
+         these, CreateFromSpirv throws FileNotFoundException at runtime (Silk.NET.Shaderc.Shaderc.GetApi
+         can't find libshaderc_shared) the first time anything compiles a shader. -->
+    <PackageReference Include="Silk.NET.Shaderc.Native" Version="2.23.0" />
+    <PackageReference Include="Silk.NET.SPIRV.Cross.Native" Version="2.23.0" />
+    <!-- Raw Vulkan for the new from-scratch renderer (Docs/NewRenderer.md). NeoVeldrid's own Vulkan
+         backend is built on Silk.NET.Vulkan, not this - the two don't need to match versions, since
+         GraphicsDevice.GetVulkanInfo()/BackendInfoVulkan hands back plain IntPtr/ulong handles (see
+         VulkanContext.cs), not types from whichever binding library the device was built with. -->
     <PackageReference Include="Vortice.Vulkan" Version="3.2.3" />
   </ItemGroup>
 

--- a/ReLunacy.Engine/Rendering/AssetManager.cs
+++ b/ReLunacy.Engine/Rendering/AssetManager.cs
@@ -4,7 +4,7 @@ using ReLunacy.Engine.Loading.Readers;
 using ReLunacy.Engine.Rendering.Resources;
 using ReLunacy.Engine.Rendering.Vulkan;
 using ReLunacy.Engine.Scene;
-using Veldrith;
+using NeoVeldrid;
 using IMesh = ReLunacy.Engine.Assets.Interfaces.IMesh;
 
 namespace ReLunacy.Engine.Rendering;
@@ -235,8 +235,8 @@ public sealed class AssetManager : IDisposable
     // effect's declared set 10 is never bound to nothing (an unbound descriptor set is undefined
     // behaviour - the same class of fault BuildLitModelEffect documents). See CubemapReader for the
     // face format and LitModelShaderSource for how it's sampled.
-    private Veldrith.Texture? _environmentCubemap;
-    public Veldrith.TextureView? EnvironmentCubemapView { get; private set; }
+    private NeoVeldrid.Texture? _environmentCubemap;
+    public NeoVeldrid.TextureView? EnvironmentCubemapView { get; private set; }
 
     private void BuildEnvironmentCubemap(LevelData level)
     {
@@ -244,9 +244,9 @@ public sealed class AssetManager : IDisposable
         int size = cubemap?.FaceSize ?? 1;
         var factory = _gd.ResourceFactory;
 
-        var tex = factory.CreateTexture(Veldrith.TextureDescription.Texture2D(
-            (uint)size, (uint)size, 1, 6, Veldrith.PixelFormat.R8G8B8A8UNorm,
-            Veldrith.TextureUsage.Sampled | Veldrith.TextureUsage.Cubemap));
+        var tex = factory.CreateTexture(NeoVeldrid.TextureDescription.Texture2D(
+            (uint)size, (uint)size, 1, 6, NeoVeldrid.PixelFormat.R8_G8_B8_A8_UNorm,
+            NeoVeldrid.TextureUsage.Sampled | NeoVeldrid.TextureUsage.Cubemap));
 
         // Face order is the file's own +X,-X,+Y,-Y,+Z,-Z, which is exactly the cube array-layer
         // order Vulkan expects, so layer index == face index with no remap.
@@ -644,8 +644,8 @@ public sealed class AssetManager : IDisposable
 
     private Sampler GetSamplerFor(TextureFiltering filtering) => filtering switch
     {
-        TextureFiltering.Bilinear => _linearWrapSampler ??= CreateWrapSampler(SamplerFilter.MinLinearMagLinearMipLinear),
-        _ => _pointWrapSampler ??= CreateWrapSampler(SamplerFilter.MinPointMagPointMipPoint),
+        TextureFiltering.Bilinear => _linearWrapSampler ??= CreateWrapSampler(SamplerFilter.MinLinear_MagLinear_MipLinear),
+        _ => _pointWrapSampler ??= CreateWrapSampler(SamplerFilter.MinPoint_MagPoint_MipPoint),
     };
 
     private Sampler CreateWrapSampler(SamplerFilter filter) => _gd.ResourceFactory.CreateSampler(new SamplerDescription(

--- a/ReLunacy.Engine/Rendering/Resources/GpuTexture.cs
+++ b/ReLunacy.Engine/Rendering/Resources/GpuTexture.cs
@@ -1,4 +1,4 @@
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Engine.Rendering.Resources;
 
@@ -129,7 +129,7 @@ public sealed class GpuTexture : IDisposable
         Height = height;
         MipLevels = mipLevels;
         DeviceTexture = graphicsDevice.ResourceFactory.CreateTexture(TextureDescription.Texture2D(
-            Width, Height, MipLevels, 1, PixelFormat.R8G8B8A8UNorm, TextureUsage.Sampled));
+            Width, Height, MipLevels, 1, PixelFormat.R8_G8_B8_A8_UNorm, TextureUsage.Sampled));
     }
 
     /// <summary>Uploads every mip of an already-prepared chain in one call - the original, immediate,

--- a/ReLunacy.Engine/Rendering/Resources/MaterialMap.cs
+++ b/ReLunacy.Engine/Rendering/Resources/MaterialMap.cs
@@ -33,9 +33,9 @@ public readonly record struct MaterialMapKey(string Name)
 /// The scalar is not decoration. Several of the game's per-material constants (alpha-clip threshold,
 /// parallax scale/bias, detail tiling, "this material has a real bake") are carried in it, which is why
 /// a map with no texture at all is still worth storing.</summary>
-public sealed class MaterialMap(GpuTexture? texture = null, Veldrith.Sampler? sampler = null, float value = 0f)
+public sealed class MaterialMap(GpuTexture? texture = null, NeoVeldrid.Sampler? sampler = null, float value = 0f)
 {
     public GpuTexture? Texture = texture;
-    public Veldrith.Sampler? Sampler = sampler;
+    public NeoVeldrid.Sampler? Sampler = sampler;
     public float Value = value;
 }

--- a/ReLunacy.Engine/Rendering/SceneLighting.cs
+++ b/ReLunacy.Engine/Rendering/SceneLighting.cs
@@ -1,5 +1,5 @@
 using System.Numerics;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Engine.Rendering;
 
@@ -8,7 +8,7 @@ namespace ReLunacy.Engine.Rendering;
 /// This used to live on DecalAwareForwardRenderer, which meant the raw-Vulkan renderer could only get
 /// at the level's lighting by going through a Bliss renderer it otherwise no longer uses. It is plain
 /// state with one pure builder, so it belongs on its own: only <see cref="EnvironmentCubemap"/> touches
-/// the graphics API at all, and that is a Veldrith type, not a Bliss one.
+/// the graphics API at all, and that is a NeoVeldrid type, not a Bliss one.
 ///
 /// Values default to a plain downward light; the view pushes the real EditorSettings values every
 /// frame, same pattern as Camera.FarPlane / VolumeWireThickness.</summary>

--- a/ReLunacy.Engine/Rendering/Vulkan/VkMaterialBuilder.cs
+++ b/ReLunacy.Engine/Rendering/Vulkan/VkMaterialBuilder.cs
@@ -1,5 +1,5 @@
 using ReLunacy.Engine.Rendering.Resources;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Engine.Rendering.Vulkan;
 
@@ -40,7 +40,7 @@ public static class VkMaterialBuilder
         };
     }
 
-    /// <summary>A material map's texture as a Veldrith texture. Every material has
+    /// <summary>A material map's texture as a NeoVeldrid texture. Every material has
     /// albedo/normal/properties/fLightColour/fLightDir maps (AssetManager provides defaults), so these
     /// are normally non-null; null is handled by the renderer.</summary>
     private static Texture? TextureOf(RenderMaterial material, MaterialMapKey key) =>

--- a/ReLunacy.Engine/Rendering/Vulkan/VulkanContext.cs
+++ b/ReLunacy.Engine/Rendering/Vulkan/VulkanContext.cs
@@ -1,4 +1,4 @@
-using Veldrith;
+using NeoVeldrid;
 using Vortice.Vulkan;
 
 namespace ReLunacy.Engine.Rendering.Vulkan;
@@ -6,13 +6,15 @@ namespace ReLunacy.Engine.Rendering.Vulkan;
 /// <summary>Stage 0 of the from-scratch raw-Vulkan renderer (see Docs/NewRenderer.md).
 ///
 /// The new renderer does NOT create its own Vulkan instance/device - during the staged migration it
-/// SHARES Veldrith's, so the window, swapchain, ImGui and present all keep working while only the
-/// scene pass moves to raw Vulkan. Veldrith exposes the handles via
-/// <c>GraphicsDevice.GetVulkanInfo(out BackendInfoVulkan)</c> as raw <see langword="nint"/>s; this
-/// wraps them into the Vortice.Vulkan handle types (pinned to Veldrith's exact Vortice version so
-/// they are the same structs). From here later stages build their own command pool, pipelines,
-/// descriptor sets and SIMULTANEOUS_USE command buffers to get record-once/replay - the thing
-/// Veldrith's ONE_TIME_SUBMIT command lists cannot do.</summary>
+/// SHARES NeoVeldrid's, so the window, swapchain, ImGui and present all keep working while only the
+/// scene pass moves to raw Vulkan. NeoVeldrid exposes the handles via
+/// <c>GraphicsDevice.GetVulkanInfo(out BackendInfoVulkan)</c> as raw <see langword="nint"/>s/
+/// <see langword="ulong"/>s - a binding-agnostic escape hatch, not tied to whatever Vulkan binding
+/// NeoVeldrid itself uses internally (Silk.NET.Vulkan) - so this wraps them into the Vortice.Vulkan
+/// handle types this project's own raw-Vulkan code uses, with no version-matching needed either way.
+/// From here later stages build their own command pool, pipelines, descriptor sets and
+/// SIMULTANEOUS_USE command buffers to get record-once/replay - the thing NeoVeldrid's ONE_TIME_SUBMIT
+/// command lists cannot do.</summary>
 public sealed class VulkanContext
 {
     public VkInstance Instance { get; }
@@ -21,17 +23,29 @@ public sealed class VulkanContext
     public VkQueue GraphicsQueue { get; }
     public uint GraphicsQueueFamilyIndex { get; }
 
-    /// <summary>Vortice's per-instance and per-device function tables. Veldrith's own
-    /// (VkGraphicsDevice.DeviceApi) is on a private type we can't reach, so we build our own bound to
-    /// the SAME shared handles. The base loader is already initialised by Veldrith, so
-    /// Vulkan.GetApi/new VkDeviceApi just resolve entry points against these handles.</summary>
+    /// <summary>Vortice's per-instance and per-device function tables. NeoVeldrid's own internal API
+    /// table is on a private type we can't reach, so we build our own bound to the SAME shared
+    /// handles.</summary>
     public VkInstanceApi InstanceApi { get; }
     public VkDeviceApi DeviceApi { get; }
 
-    /// <summary>Kept so the renderer can call <c>GetVkImage(Veldrith.Texture)</c> - the only supported
-    /// way to reach a Veldrith-owned texture's raw VkImage, which is how the scene renders into an
-    /// image ImGui already displays.</summary>
+    /// <summary>Kept so the renderer can call <c>GetVkImage(NeoVeldrid.Texture)</c> - the only
+    /// supported way to reach a NeoVeldrid-owned texture's raw VkImage, which is how the scene
+    /// renders into an image ImGui already displays.</summary>
     public BackendInfoVulkan BackendInfo { get; }
+
+    /// <summary>Vortice.Vulkan keeps its own static <c>vkGetInstanceProcAddr</c> function pointer,
+    /// populated only by an explicit <see cref="Vortice.Vulkan.Vulkan.vkInitialize"/> call (which loads
+    /// libvulkan itself and resolves it) - <see cref="Vortice.Vulkan.Vulkan.GetApi(VkInstance)"/> calls
+    /// through that pointer to build the instance/device tables, so it must run first. Under the old
+    /// Veldrith fork this happened to already be populated (Veldrith used Vortice.Vulkan internally too,
+    /// as a side effect of building its own device), which is why this was never called explicitly here.
+    /// NeoVeldrid uses Silk.NET.Vulkan instead and never touches Vortice.Vulkan's static state, so
+    /// without this the pointer stays null and GetApi segfaults dereferencing it - confirmed by
+    /// decompiling Vortice.Vulkan.dll and matching the crash site to right here. vkInitialize() just
+    /// takes another handle to the already-loaded libvulkan.so.1/vulkan-1.dll, so this is safe to call
+    /// even though NeoVeldrid loaded it first.</summary>
+    private static bool s_vortriceInitialized;
 
     public VulkanContext(GraphicsDevice graphicsDevice)
     {
@@ -39,6 +53,12 @@ public sealed class VulkanContext
             throw new InvalidOperationException(
                 "The new renderer requires the Vulkan backend; GraphicsDevice.GetVulkanInfo failed.");
         BackendInfo = info;
+
+        if (!s_vortriceInitialized)
+        {
+            Vortice.Vulkan.Vulkan.vkInitialize().CheckResult("Vortice.Vulkan.Vulkan.vkInitialize failed");
+            s_vortriceInitialized = true;
+        }
 
         Instance = new VkInstance(info.Instance);
         PhysicalDevice = new VkPhysicalDevice(info.PhysicalDevice);

--- a/ReLunacy.Engine/Rendering/Vulkan/VulkanRenderer.cs
+++ b/ReLunacy.Engine/Rendering/Vulkan/VulkanRenderer.cs
@@ -1,6 +1,6 @@
 using System.Numerics;
-using Veldrith;
-using Veldrith.SPIRV;
+using NeoVeldrid;
+using NeoVeldrid.SPIRV;
 using Vortice.Vulkan;
 
 namespace ReLunacy.Engine.Rendering.Vulkan;
@@ -552,7 +552,7 @@ void main() { o = vec4(uColor.rgb, 1.0); }";
     /// <summary>Draws that survived this frame's culling, across every bucket.</summary>
     public int VisibleDrawCount => _visOpaqueCount + _visTransCount + _visAddCount + _visSoftCount + _visBillCount;
 
-    /// <summary>The Veldrith texture the scene is rendered into - display this in ImGui.</summary>
+    /// <summary>The NeoVeldrid texture the scene is rendered into - display this in ImGui.</summary>
     /// <summary>The scene image for ImGui to display. This is the LAST COMPLETED frame, not the one
     /// being recorded, so the viewport runs one frame behind the camera - the cost of the overlap.</summary>
     public Texture ColorTexture => _colorTex[_displaySlot];
@@ -1430,7 +1430,7 @@ void main() { o = vec4(uColor.rgb, 1.0); }";
     private static Texture CreateFallbackCubemap(GraphicsDevice gd)
     {
         var tex = gd.ResourceFactory.CreateTexture(TextureDescription.Texture2D(
-            1, 1, 1, 6, PixelFormat.R8G8B8A8UNorm, TextureUsage.Sampled | TextureUsage.Cubemap));
+            1, 1, 1, 6, PixelFormat.R8_G8_B8_A8_UNorm, TextureUsage.Sampled | TextureUsage.Cubemap));
         var grey = new byte[] { 128, 128, 128, 128 };
         for (uint face = 0; face < 6; face++)
             gd.UpdateTexture(tex, grey, 0, 0, 0, 1, 1, 1, 0, face);
@@ -1465,7 +1465,7 @@ void main() { o = vec4(uColor.rgb, 1.0); }";
     {
         for (int f = 0; f < Frames; f++)
         {
-            _colorTex[f] = gd.ResourceFactory.CreateTexture(TextureDescription.Texture2D(_width, _height, 1, 1, PixelFormat.R8G8B8A8UNorm, TextureUsage.Sampled | TextureUsage.RenderTarget));
+            _colorTex[f] = gd.ResourceFactory.CreateTexture(TextureDescription.Texture2D(_width, _height, 1, 1, PixelFormat.R8_G8_B8_A8_UNorm, TextureUsage.Sampled | TextureUsage.RenderTarget));
             _colorImage[f] = _ctx.BackendInfo.GetVkImage(_colorTex[f]);
             var cvi = new VkImageViewCreateInfo { image = _colorImage[f], viewType = VkImageViewType.Image2D, format = ColorFormat, components = default, subresourceRange = new VkImageSubresourceRange { aspectMask = VkImageAspectFlags.Color, baseMipLevel = 0, levelCount = 1, baseArrayLayer = 0, layerCount = 1 } };
             VkImageView cv; Check(_api.vkCreateImageView(&cvi, &cv), "vkCreateImageView(color)"); _colorView[f] = cv;

--- a/ReLunacy.Engine/Rendering/Vulkan/VulkanSceneCapture.cs
+++ b/ReLunacy.Engine/Rendering/Vulkan/VulkanSceneCapture.cs
@@ -1,11 +1,11 @@
 using System.Runtime.CompilerServices;
 using ReLunacy.Engine.Rendering.Resources;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Engine.Rendering.Vulkan;
 
 /// <summary>One material's inputs for the raw-Vulkan lit renderer: the five sampled textures (the
-/// Veldrith textures behind the material's maps) plus the per-material scalars the shader needs - the baked
+/// NeoVeldrid textures behind the material's maps) plus the per-material scalars the shader needs - the baked
 /// flag, parallax scale/bias, the alpha-clip threshold, and a render mode (1 = cutout/alpha-clip).
 /// Textures may be null (the renderer falls back to a real texture).</summary>
 public struct VkMaterialDesc

--- a/ReLunacy.Engine/Scene/EntityCluster.cs
+++ b/ReLunacy.Engine/Scene/EntityCluster.cs
@@ -2,7 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using ReLunacy.Engine.Assets.Interfaces;
 using ReLunacy.Engine.Assets.LevelElements;
 using ReLunacy.Engine.Rendering;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Engine.Scene;
 

--- a/ReLunacy.Engine/Scene/EntityFoliage.cs
+++ b/ReLunacy.Engine/Scene/EntityFoliage.cs
@@ -2,7 +2,7 @@ using System.Numerics;
 using ReLunacy.Engine.Rendering.Resources;
 using ReLunacy.Engine.Assets.Interfaces;
 using ReLunacy.Engine.Rendering;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Engine.Scene;
 

--- a/ReLunacy.Engine/Scene/EntityManager.cs
+++ b/ReLunacy.Engine/Scene/EntityManager.cs
@@ -2,7 +2,7 @@ using System.Numerics;
 using ReLunacy.Engine.Assets.Levels;
 using ReLunacy.Engine.Diagnostics;
 using ReLunacy.Engine.Rendering;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Engine.Scene;
 

--- a/ReLunacy.Engine/Scene/EntityMoby.cs
+++ b/ReLunacy.Engine/Scene/EntityMoby.cs
@@ -3,7 +3,7 @@ using ReLunacy.Engine.Rendering.Resources;
 using ReLunacy.Engine.Assets.Interfaces;
 using ReLunacy.Engine.Diagnostics;
 using ReLunacy.Engine.Rendering;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Engine.Scene;
 

--- a/ReLunacy.Engine/Scene/EntityRegion.cs
+++ b/ReLunacy.Engine/Scene/EntityRegion.cs
@@ -1,6 +1,6 @@
 using ReLunacy.Engine.Assets.Levels;
 using ReLunacy.Engine.Rendering;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Engine.Scene;
 

--- a/ReLunacy.Engine/Scene/EntityTie.cs
+++ b/ReLunacy.Engine/Scene/EntityTie.cs
@@ -2,7 +2,7 @@ using System.Numerics;
 using ReLunacy.Engine.Rendering.Resources;
 using ReLunacy.Engine.Assets.Interfaces;
 using ReLunacy.Engine.Rendering;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Engine.Scene;
 

--- a/ReLunacy.Engine/Scene/EntityUFrag.cs
+++ b/ReLunacy.Engine/Scene/EntityUFrag.cs
@@ -2,7 +2,7 @@ using System.Numerics;
 using ReLunacy.Engine.Rendering.Resources;
 using ReLunacy.Engine.Assets.Interfaces;
 using ReLunacy.Engine.Rendering;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Engine.Scene;
 

--- a/ReLunacy.Engine/Scene/EntityVolume.cs
+++ b/ReLunacy.Engine/Scene/EntityVolume.cs
@@ -2,7 +2,7 @@ using System.Numerics;
 using ReLunacy.Engine.Rendering.Resources;
 using ReLunacy.Engine.Assets.LevelElements;
 using ReLunacy.Engine.Rendering;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Engine.Scene;
 

--- a/ReLunacy.Engine/Scene/EntityZone.cs
+++ b/ReLunacy.Engine/Scene/EntityZone.cs
@@ -1,6 +1,6 @@
 using ReLunacy.Engine.Assets.Interfaces;
 using ReLunacy.Engine.Rendering;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Engine.Scene;
 

--- a/ReLunacy/Core/Frames/DockedFrames/AssetViewer.cs
+++ b/ReLunacy/Core/Frames/DockedFrames/AssetViewer.cs
@@ -10,7 +10,7 @@ using ReLunacy.Engine.Rendering;
 using ReLunacy.Engine.Scene;
 using ReLunacy.Utility;
 using ReLunacy.Utility.Localization;
-using Veldrith;
+using NeoVeldrid;
 using IMesh = ReLunacy.Engine.Assets.Interfaces.IMesh;
 
 namespace ReLunacy.Core.Frames.DockedFrames;
@@ -117,8 +117,10 @@ public class AssetViewer : DockedFrame, ILevelListener
     // The preview image, its toolbar, and the rules for which of them gets a click. Same component the
     // level view uses, so the two cannot drift apart on where the mouse is or who gets it.
     private readonly Viewport3D _viewport = new();
-    private readonly MouseGrabHandler rmbghandler = new() { mouseButton = MouseButton.Right };
-    private readonly MouseGrabHandler mmbghandler = new() { mouseButton = MouseButton.Middle };
+    // Qualified: NeoVeldrid also exports a MouseButton type, ambiguous against this project's own
+    // SDL-based one (ReLunacy.Utility.MouseButton, what MouseGrabHandler actually expects).
+    private readonly MouseGrabHandler rmbghandler = new() { mouseButton = ReLunacy.Utility.MouseButton.Right };
+    private readonly MouseGrabHandler mmbghandler = new() { mouseButton = ReLunacy.Utility.MouseButton.Middle };
     private readonly GraphicsDevice graphicsDevice;
     // The preview is drawn by the SAME raw-Vulkan renderer the level view uses, rebuilt whenever the
     // selection changes. That is the point: a preview on a different renderer is a bad reference for

--- a/ReLunacy/Core/Frames/DockedFrames/EditorSettingsFrame.cs
+++ b/ReLunacy/Core/Frames/DockedFrames/EditorSettingsFrame.cs
@@ -1,7 +1,7 @@
 using System.Numerics;
 using ReLunacy.Utility;
 using ReLunacy.Utility.Localization;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Core.Frames.DockedFrames;
 
@@ -24,7 +24,7 @@ internal class EditorSettingsFrame : Frame
     public EditorSettingsFrame()
     {
         FrameName = LM.Get("GUI_Frame_EditorSettings");
-        maxMsaa = (int)LunaWindow.Instance.GraphicsDevice.GetSampleCountLimit(PixelFormat.R8G8B8A8SInt, false);
+        maxMsaa = (int)LunaWindow.Instance.GraphicsDevice.GetSampleCountLimit(PixelFormat.R8_G8_B8_A8_SInt, false);
         Languages = [.. LM.Languages.Select(l => l.Value.LangName)];
     }
 

--- a/ReLunacy/Core/Frames/DockedFrames/ProfilerFrame.cs
+++ b/ReLunacy/Core/Frames/DockedFrames/ProfilerFrame.cs
@@ -8,7 +8,7 @@ namespace ReLunacy.Core.Frames.DockedFrames;
 /// frame go?" - command recording, submission, the GPU-idle stall, present - and prints a verdict
 /// naming the dominant cost so the next optimisation target is obvious.
 ///
-/// The numbers are CPU wall-clock: there is no GPU timestamp query in Veldrith, so the GPU's own
+/// The numbers are CPU wall-clock: there is no GPU timestamp query in NeoVeldrid, so the GPU's own
 /// per-pass time can't be read. The "GPU Wait" phase (the per-frame WaitForIdle) is the stand-in -
 /// it is exactly how long the CPU sat blocked for the GPU to finish, which is the honest measure of
 /// the GPU tail as long as the frame ends with a full sync. See FrameProfiler's class summary.</summary>

--- a/ReLunacy/Core/Frames/DockedFrames/View3D.cs
+++ b/ReLunacy/Core/Frames/DockedFrames/View3D.cs
@@ -5,7 +5,7 @@ using ReLunacy.Engine.Scene;
 using ReLunacy.Engine.Diagnostics;
 using ReLunacy.Utility;
 using ReLunacy.Utility.Localization;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Core.Frames.DockedFrames;
 
@@ -49,7 +49,9 @@ public class View3D : DockedFrame
     public Vector2 ViewportScreenPos => _viewport.ScreenPos;
     public Vector2 ViewportSize => _viewport.Size;
 
-    private readonly MouseGrabHandler rmbghandler = new() { mouseButton = MouseButton.Right };
+    // Qualified: NeoVeldrid also exports a MouseButton type, ambiguous against this project's own
+    // SDL-based one (ReLunacy.Utility.MouseButton, what MouseGrabHandler actually expects).
+    private readonly MouseGrabHandler rmbghandler = new() { mouseButton = ReLunacy.Utility.MouseButton.Right };
 
     public Entity? SelectedEntity
     {

--- a/ReLunacy/Core/Window.cs
+++ b/ReLunacy/Core/Window.cs
@@ -13,7 +13,7 @@ using ReLunacy.Engine.Scene;
 using ReLunacy.MenuBar;
 using ReLunacy.Utility;
 using ReLunacy.Utility.Localization;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Core;
 
@@ -87,7 +87,7 @@ public class LunaWindow : IDisposable
         {
             Debug = false,
             HasMainSwapchain = true,
-            SwapchainDepthFormat = PixelFormat.D32FloatS8UInt,
+            SwapchainDepthFormat = PixelFormat.D32_Float_S8_UInt,
             SyncToVerticalBlank = EditorSettings.VSync,
             ResourceBindingModel = ResourceBindingModel.Improved,
             PreferDepthRangeZeroToOne = true,
@@ -589,7 +589,7 @@ public class LunaWindow : IDisposable
             commandList.End();
             graphicsDevice.SubmitCommands(commandList);
         }
-        // Veldrith's Vulkan backend only signals a render-finished semaphore before presenting
+        // NeoVeldrid's Vulkan backend only signals a render-finished semaphore before presenting
         // when the present queue differs from the graphics queue - on a shared queue (the common
         // case on desktop GPUs), SwapBuffers's vkQueuePresentKHR call waits on nothing at all, so
         // without this the presentation engine can read the swapchain image before the GPU has

--- a/ReLunacy/Locales/en.json
+++ b/ReLunacy/Locales/en.json
@@ -205,7 +205,7 @@
         "GUI_Frame_Profiler_Avg": "Avg (ms)",
         "GUI_Frame_Profiler_Percent": "% of frame",
         "GUI_Frame_Profiler_Counters": "Counters",
-        "GUI_Frame_Profiler_GpuNote": "\"GPU Wait\" is the per-frame WaitForIdle stall - the CPU blocked on the GPU. It stands in for GPU cost since Veldrith exposes no GPU timestamp query.",
+        "GUI_Frame_Profiler_GpuNote": "\"GPU Wait\" is the per-frame WaitForIdle stall - the CPU blocked on the GPU. It stands in for GPU cost since NeoVeldrid exposes no GPU timestamp query.",
         "GUI_Frame_OpenLevel": "Open level",
         "GUI_Frame_OpenLevel_LevelPath": "Level Path",
         "GUI_Frame_OpenLevel_PasteClipboard": "Paste",

--- a/ReLunacy/Program.cs
+++ b/ReLunacy/Program.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using ReLunacy.Core;
 using ReLunacy.Utility;
+using ReLunacy.Utility.Host;
 
 namespace ReLunacy;
 
@@ -17,6 +18,10 @@ public class Program
 
     static void Main(string[] args)
     {
+        // Must happen before anything touches shader compilation (WarmUpShaderCache, FullscreenBlit,
+        // ImGuiController all call CreateFromSpirv) - see NativeLibraryPreloader's remarks.
+        NativeLibraryPreloader.PreloadShaderCompilers();
+
         if (args.Length > 0)
             ProvidedPath = args[0];
 

--- a/ReLunacy/ReLunacy.csproj
+++ b/ReLunacy/ReLunacy.csproj
@@ -54,9 +54,15 @@
          referenced directly now. -->
     <PackageReference Include="StbImageSharp" Version="2.30.15" />
     <PackageReference Include="StbImageWriteSharp" Version="1.16.7" />
-    <PackageReference Include="Veldrith" Version="1.2.19" />
+    <!-- Was Veldrith (Stellution-Studios), a single-maintainer fork - moved to NeoVeldrid, the
+         actively-maintained Silk.NET-based continuation of Veldrid. See ReLunacy.Engine.csproj's
+         comment for why, and EditorWindow.cs for the Direct3D12/Metal backend removal that came with it. -->
+    <PackageReference Include="NeoVeldrid" Version="1.2.1" />
     <!-- GLSL to SPIR-V, for the ImGui shaders and the fullscreen blit. Came in through Bliss. -->
-    <PackageReference Include="Veldrith.SPIRV" Version="1.2.19" />
+    <PackageReference Include="NeoVeldrid.SPIRV" Version="1.2.1" />
+    <!-- Native libraries CreateFromSpirv needs at runtime - see ReLunacy.Engine.csproj's comment. -->
+    <PackageReference Include="Silk.NET.Shaderc.Native" Version="2.23.0" />
+    <PackageReference Include="Silk.NET.SPIRV.Cross.Native" Version="2.23.0" />
     <PackageReference Include="Vortice.Vulkan" Version="3.2.3" />
   </ItemGroup>
 

--- a/ReLunacy/Utility/EditorSettings.cs
+++ b/ReLunacy/Utility/EditorSettings.cs
@@ -1,7 +1,7 @@
 using System.Numerics;
 using Newtonsoft.Json;
 using ReLunacy.Utility;
-using Veldrith;
+using NeoVeldrid;
 
 public enum UpdateChannel
 {

--- a/ReLunacy/Utility/Host/EditorWindow.cs
+++ b/ReLunacy/Utility/Host/EditorWindow.cs
@@ -1,12 +1,12 @@
 using SDL3;
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Utility;
 
 /// <summary>The application's OS window, and the graphics device drawing into it.
 ///
 /// A thin wrapper over SDL3: create the window, pump its event queue (handing every event to
-/// <see cref="Input"/>), and hand Veldrith the native handles it needs for a swapchain.</summary>
+/// <see cref="Input"/>), and hand NeoVeldrid the native handles it needs for a swapchain.</summary>
 public sealed class EditorWindow : IDisposable
 {
     private nint _handle;
@@ -43,10 +43,12 @@ public sealed class EditorWindow : IDisposable
         // is sized in pixels and every hit test compares against ImGui's display size, so the two spaces
         // have to stay the same one. Supporting a scaled display means converting at the input boundary,
         // not just asking for the bigger surface.
+        // Metal is gone as of the NeoVeldrid migration (see ReLunacy.Engine.csproj's comment) - macOS
+        // now goes through Vulkan via MoltenVK like every other platform, so the Vulkan case already
+        // covers it and there is no longer a separate flag to request here.
         var flags = SDL.WindowFlags.Resizable | preferredBackend switch
         {
             GraphicsBackend.Vulkan => SDL.WindowFlags.Vulkan,
-            GraphicsBackend.Metal => SDL.WindowFlags.Metal,
             _ => 0,
         };
 
@@ -69,13 +71,12 @@ public sealed class EditorWindow : IDisposable
         return backend switch
         {
             GraphicsBackend.Vulkan => GraphicsDevice.CreateVulkan(options, description),
-            GraphicsBackend.Direct3D12 => GraphicsDevice.CreateD3D12(options, description),
-            GraphicsBackend.Metal => GraphicsDevice.CreateMetal(options, description),
-            _ => throw new VeldridException($"Invalid GraphicsBackend: [{backend}]"),
+            GraphicsBackend.Direct3D11 => GraphicsDevice.CreateD3D11(options, description),
+            _ => throw new NeoVeldridException($"Invalid GraphicsBackend: [{backend}]"),
         };
     }
 
-    /// <summary>The platform-native handles behind this window, in the shape Veldrith wants.
+    /// <summary>The platform-native handles behind this window, in the shape NeoVeldrid wants.
     ///
     /// SDL exposes them as window "properties" rather than as typed accessors, which is why this reads
     /// like a lookup table. Wayland is checked before X11 because a session running XWayland reports
@@ -110,7 +111,7 @@ public sealed class EditorWindow : IDisposable
                 return SwapchainSource.CreateXlib(x11Display, (nint)x11Window);
         }
 
-        throw new PlatformNotSupportedException("Could not find a native window handle SDL and Veldrith agree on.");
+        throw new PlatformNotSupportedException("Could not find a native window handle SDL and NeoVeldrid agree on.");
     }
 
     /// <summary>Size of the drawable surface, NOT of the window in desktop coordinates. The two differ

--- a/ReLunacy/Utility/Host/FullscreenBlit.cs
+++ b/ReLunacy/Utility/Host/FullscreenBlit.cs
@@ -1,6 +1,6 @@
 using System.Text;
-using Veldrith;
-using Veldrith.SPIRV;
+using NeoVeldrid;
+using NeoVeldrid.SPIRV;
 
 namespace ReLunacy.Utility;
 
@@ -73,9 +73,9 @@ public sealed class FullscreenBlit : IDisposable
         if (_pipelines.TryGetValue(output, out var cached)) return cached;
 
         var description = new GraphicsPipelineDescription(
-            BlendStateDescription.SINGLE_OVERRIDE_BLEND,
-            DepthStencilStateDescription.DISABLED,
-            RasterizerStateDescription.CULL_NONE,
+            BlendStateDescription.SingleOverrideBlend,
+            DepthStencilStateDescription.Disabled,
+            RasterizerStateDescription.CullNone,
             PrimitiveTopology.TriangleList,
             new ShaderSetDescription([], _shaders),
             [_layout],

--- a/ReLunacy/Utility/Host/MainRenderTarget.cs
+++ b/ReLunacy/Utility/Host/MainRenderTarget.cs
@@ -1,4 +1,4 @@
-using Veldrith;
+using NeoVeldrid;
 
 namespace ReLunacy.Utility;
 
@@ -28,8 +28,8 @@ public sealed class MainRenderTarget : IDisposable
 
     public MainRenderTarget(
         GraphicsDevice graphicsDevice, uint width, uint height, TextureSampleCount sampleCount,
-        PixelFormat colorFormat = PixelFormat.R8G8B8A8UNorm,
-        PixelFormat depthFormat = PixelFormat.D32FloatS8UInt)
+        PixelFormat colorFormat = PixelFormat.R8_G8_B8_A8_UNorm,
+        PixelFormat depthFormat = PixelFormat.D32_Float_S8_UInt)
     {
         _graphicsDevice = graphicsDevice;
         _colorFormat = colorFormat;

--- a/ReLunacy/Utility/Host/NativeLibraryPreloader.cs
+++ b/ReLunacy/Utility/Host/NativeLibraryPreloader.cs
@@ -1,0 +1,61 @@
+using System.Runtime.InteropServices;
+
+namespace ReLunacy.Utility.Host;
+
+/// <summary>Preloads native libraries Silk.NET's own loader fails to find on its own.
+///
+/// NeoVeldrid.SPIRV's shader compilation (Silk.NET.Shaderc / Silk.NET.SPIRV.Cross) ships its native
+/// libraries under the standard NuGet runtimes/{rid}/native/ layout, which the CLR's built-in P/Invoke
+/// resolver knows to search - but Silk.NET uses its own loader (Silk.NET.Core's SearchPathContainer),
+/// which does not check that folder. A bare-name load (what Shaderc.GetApi()/Cross.GetApi() do
+/// internally, and what CreateFromSpirv triggers the first time anything compiles a shader) then fails
+/// with FileNotFoundException even though the file is right there - confirmed:
+/// NativeLibrary.TryLoad("libshaderc_shared.so") fails, but NativeLibrary.Load(fullPath) to the exact
+/// same file succeeds. Loading it explicitly once, before anything calls into Shaderc/Cross, is enough:
+/// once a shared object is resident in the process, later bare-name lookups for it resolve against the
+/// already-loaded copy instead of searching again.</summary>
+internal static class NativeLibraryPreloader
+{
+    public static void PreloadShaderCompilers()
+    {
+        Preload("shaderc_shared");
+        Preload("spirv-cross");
+    }
+
+    private static void Preload(string baseName)
+    {
+        string fileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? $"{baseName}.dll"
+            : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? $"lib{baseName}.dylib"
+            : $"lib{baseName}.so";
+
+        string path = Path.Combine(AppContext.BaseDirectory, "runtimes", GetRid(), "native", fileName);
+        if (!File.Exists(path))
+        {
+            Console.WriteLine($"Warning: native library not found for preload: {path}");
+            return;
+        }
+
+        try { NativeLibrary.Load(path); }
+        catch (Exception e) { Console.WriteLine($"Warning: failed to preload {path}: {e.Message}"); }
+    }
+
+    /// <summary>The subset of RIDs NeoVeldrid.SPIRV's native packages actually ship - not
+    /// RuntimeInformation.RuntimeIdentifier, which can report a more specific distro RID
+    /// (e.g. "fedora.42-x64") that has no matching folder in a NuGet package built for the
+    /// generic RID graph.</summary>
+    private static string GetRid()
+    {
+        string arch = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.X86 => "x86",
+            Architecture.Arm64 => "arm64",
+            Architecture.Arm => "arm",
+            var other => throw new PlatformNotSupportedException($"Unsupported architecture: {other}"),
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return $"win-{arch}";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return $"osx-{arch}";
+        return $"linux-{arch}";
+    }
+}

--- a/ReLunacy/Utility/ImGuiController.cs
+++ b/ReLunacy/Utility/ImGuiController.cs
@@ -1,8 +1,8 @@
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Veldrith;
-using Veldrith.SPIRV;
+using NeoVeldrid;
+using NeoVeldrid.SPIRV;
 
 namespace ReLunacy.Utility;
 
@@ -115,7 +115,7 @@ public class ImGuiController : IDisposable
         var vertexLayoutDescription = new VertexLayoutDescription(
             new VertexElementDescription("in_position", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float2),
             new VertexElementDescription("in_texCoord", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float2),
-            new VertexElementDescription("in_color", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Byte4Norm));
+            new VertexElementDescription("in_color", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Byte4_Norm));
 
         var shaderDir = Path.Combine(Program.EditorPath, "Shaders", "ImGui");
         byte[] imguiVertData = File.ReadAllBytes(Path.Combine(shaderDir, "default.vert"));
@@ -136,11 +136,10 @@ public class ImGuiController : IDisposable
             new ResourceLayoutElementDescription("MainTexture", ResourceKind.TextureReadOnly, ShaderStages.Fragment)));
 
         var pipelineDescription = new GraphicsPipelineDescription(
-            BlendStateDescription.SINGLE_ALPHA_BLEND,
+            BlendStateDescription.SingleAlphaBlend,
             new DepthStencilStateDescription(false, false, ComparisonKind.Always),
             new RasterizerStateDescription(FaceCullMode.None, PolygonFillMode.Solid, FrontFace.Clockwise,
-                depthClipEnabled: true, depthBias: 0, slopeScaledDepthBias: 0f, depthBiasClamp: 0f,
-                scissorTestEnabled: true),
+                depthClipEnabled: true, scissorTestEnabled: true),
             PrimitiveTopology.TriangleList,
             shaderSet,
             [_layout, _textureLayout],
@@ -230,7 +229,7 @@ public class ImGuiController : IDisposable
                     }
 
                     var gpuTexture = gd.ResourceFactory.CreateTexture(TextureDescription.Texture2D(
-                        (uint)width, (uint)height, 1, 1, PixelFormat.R8G8B8A8UNorm, TextureUsage.Sampled));
+                        (uint)width, (uint)height, 1, 1, PixelFormat.R8_G8_B8_A8_UNorm, TextureUsage.Sampled));
                     gpuTexture.Name = $"ImGui Managed Texture {uniqueId}";
 
                     gd.UpdateTexture(gpuTexture, (nint)texData.Pixels, (uint)(texData.BytesPerPixel * width * height), 0, 0, 0, (uint)width, (uint)height, 1, 0, 0);

--- a/ReLunacy/Utility/VramUsageQuery.cs
+++ b/ReLunacy/Utility/VramUsageQuery.cs
@@ -1,13 +1,14 @@
-using Veldrith;
+using NeoVeldrid;
 using Vortice.Vulkan;
 
 namespace ReLunacy.Utility;
 
 /// <summary>
-/// Bliss/Veldrith expose no cross-backend GPU memory query, so this reads used VRAM directly
-/// through Vortice.Vulkan (the same binding library Veldrith's own Vulkan backend is built on,
-/// already loaded in-process) via VK_EXT_memory_budget. Vulkan-only - D3D11/D3D12/Metal/OpenGL
-/// would each need their own native query and aren't implemented; other backends always read 0.
+/// Bliss/NeoVeldrid expose no cross-backend GPU memory query, so this reads used VRAM directly
+/// through Vortice.Vulkan (already loaded in-process for this project's own raw-Vulkan renderer,
+/// independent of whatever binding NeoVeldrid itself uses internally) via VK_EXT_memory_budget.
+/// Vulkan-only - D3D11/Metal/OpenGL would each need their own native query and aren't implemented;
+/// other backends always read 0.
 /// </summary>
 internal static unsafe class VramUsageQuery
 {


### PR DESCRIPTION
Veldrith is a single-maintainer fork; NeoVeldrid is the actively-maintained Silk.NET-based continuation of Veldrid, so the renderer no longer depends on a custom graphics backend. Renamed enum/type members across the rendering code to match NeoVeldrid's API, preloads shaderc/spirv-cross's native libraries explicitly (Silk.NET's own loader doesn't check the runtimes/{rid}/native/ NuGet layout the CLR resolver would), and explicitly initializes Vortice.Vulkan's static function-pointer table before first use - it previously only worked by accident, as a side effect of Veldrith populating the same shared state internally, and silently segfaulted once NeoVeldrid stopped doing that.


Claude-Session: https://claude.ai/code/session_01VDXPkX9rfLf8zvAhxoE4D6